### PR TITLE
Release v0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     include_package_data=True,
     install_requires=ioc_requirements["install_requires"],
     dependency_links=ioc_requirements["dependency_links"],
-    setup_requires=['pytest-runner'],
+    # setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov', 'pytest-pep8']
 )
 


### PR DESCRIPTION
- Transition from `iocage` namespace to `ioc`
- Prepare distribution in FreeBSD ports