### PR TITLE
FreeBSD Release download of lib32.txz release asset

### DIFF
--- a/ioc/Release.py
+++ b/ioc/Release.py
@@ -859,7 +859,6 @@ class ReleaseGenerator(ReleaseResource):
                     urllib.request.urlretrieve(url, path)  # nosec: validated
                     self.logger.verbose(f"{url} was saved to {path}")
                     yield releaseAssetDownloadEvent.end()
-                    return
                 except urllib.error.HTTPError as http_error:
                     yield releaseAssetDownloadEvent.fail()
                     raise ioc.errors.DownloadFailed(


### PR DESCRIPTION
Do not return in Release._fetch_assets after first asset has been downloaded.

Fixes an issue downloading new Releases on FreeBSD. (reported by @igalic)