### PR TITLE
Ignoring global user defaults

### DIFF
--- a/ioc/Config/Data.py
+++ b/ioc/Config/Data.py
@@ -78,11 +78,11 @@ class Data(dict):
                 dict.__setitem__(data, key, value)
                 return
             else:
-                keys = data.keys()
+                keys = dict.keys(data)
                 current, key = key.split(self.delimiter, maxsplit=1)
                 if current not in keys:
                     dict.__setitem__(data, current, Data())
-                    data = data[current]
+                data = data[current]
 
     def __contains__(self, key: typing.Any) -> bool:
         """Return whether a (nested) key is included in the dict."""

--- a/ioc/Config/Data.py
+++ b/ioc/Config/Data.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""The common base of jail configurations."""
+import typing
+import collections.abc
+
+InputData = typing.Dict[str, typing.Any]
+
+
+class Data(dict):
+    """Internal data storage for BaseConfig objects."""
+
+    delimiter: str = "."
+
+    def __init__(
+        self,
+        data: typing.Optional[InputData]=None
+    ) -> None:
+        dict.__init__(self)
+        if data is not None:
+            for key, value in data.items():
+                self.__setitem__(key, value)
+
+    def __getitem__(
+        self,
+        key: str
+    ) -> typing.Any:
+        """Return the item while resolving nested keys."""
+        data = self
+        while True:
+            keys = dict.keys(data)
+            if self.delimiter not in key:
+                if key in keys:
+                    return dict.__getitem__(data, key)
+                else:
+                    raise KeyError(f"User property not found: {key}")
+            else:
+                current, key = key.split(self.delimiter, maxsplit=1)
+                if current not in keys:
+                    raise KeyError(f"User property not found: {current}")
+                data = data[current]
+                if isinstance(data, dict) is False:
+                    raise KeyError(f"User property is not nested: {current}")
+
+    def __setitem__(
+        self,
+        key: str,
+        value: typing.Any
+    ) -> None:
+        """Set an item in the Data dict structure and resolve nested items."""
+        data = self
+        while True:
+            if self.delimiter not in key:
+                if isinstance(value, dict) and not isinstance(value, Data):
+                    value = Data(value)
+                dict.__setitem__(data, key, value)
+                return
+            else:
+                keys = data.keys()
+                current, key = key.split(self.delimiter, maxsplit=1)
+                if current not in keys:
+                    dict.__setitem__(data, current, Data())
+                    data = data[current]
+
+    def __contains__(self, key: typing.Any) -> bool:
+        """Return whether a (nested) key is included in the dict."""
+        if isinstance(key, str) is False:
+            return False
+        data = self
+        while True:
+            keys = dict.keys(data)
+            try:
+                i = key.index(self.delimiter)
+            except ValueError:
+                return any((
+                    (key in keys) is True,
+                    (key in dict.keys(data)) is True
+                ))
+
+            current = key[0:i]
+            if current not in keys:
+                return False
+            key = key[(i + 1):]
+            data = dict.__getitem__(data, current)
+
+    def __len__(self) -> int:
+        """Return the number of items in the flattened structure."""
+        return len(self.keys())
+
+    def __delitem__(self, key: str) -> None:
+        """Delete the key from the (nested) structure."""
+        data = self
+        original_key = key
+        marked_data = None
+        marked_key = None
+        while len(key) > 0:
+            if self.delimiter not in key:
+                dict.__delitem__(data, key)
+                if (marked_data is not None) and (marked_key is not None):
+                    # delete empty parent dictionary afterwards
+                    dict.__delitem__(marked_data, marked_key)
+
+                return
+            else:
+                i = key.index(self.delimiter)
+                current = key[0:i]
+                if current in dict.keys(data):
+                    next_data = data[current]
+                    if len(dict.keys(next_data)) == 1:
+                        # mark for deletion of last remaining item
+                        marked_data = data
+                        marked_key = current
+                    else:
+                        # revoke deletion mark because a subitem has siblings
+                        marked_data = None
+                        marked_key = None
+                    data = next_data
+                    key = key[(i + 1):]
+                else:
+                    raise KeyError(original_key[:-(len(key) - 1)])
+
+    def keys(self) -> typing.KeysView[str]:
+        """Return the available configuration keys."""
+        return collections.abc.KeysView(list(self.__iter__()))  # noqa: T484
+
+    def values(self) -> typing.ValuesView[typing.Any]:
+        """Return all config values."""
+        return typing.cast(typing.ValuesView[typing.Any], self.__values())
+
+    def __values(self) -> typing.Iterator[typing.Any]:
+        yield from (value for _, value in self.__iter__())
+
+    def items(self) -> typing.ItemsView[str, typing.Any]:
+        """Iterate over the flattened keys and values."""
+        return typing.cast(
+            typing.ItemsView[str, typing.Any],
+            ((x, self.__getitem__(x)) for x in self.__iter__())
+        )
+
+    def __iter__(self) -> typing.Iterator[str]:
+        """Return the flattened dict iterator."""
+        for key in dict.__iter__(self):
+            value = dict.__getitem__(self, key)
+            if isinstance(value, Data) is True:
+                for subkey in value.__iter__():
+                    yield f"{key}.{subkey}"
+            else:
+                yield key
+
+    @property
+    def nested(self) -> dict:
+        """Return the data as nested dict structure."""
+        out = dict()
+        for key in dict.__iter__(self):
+            value = dict.__getitem__(self, key)
+            if isinstance(value, self.__class__):
+                value = value.nested
+            out[key] = value
+        return out

--- a/ioc/Config/Data.py
+++ b/ioc/Config/Data.py
@@ -22,7 +22,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""The common base of jail configurations."""
+"""Internal data storage for BaseConfig objects."""
 import typing
 import collections.abc
 

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -559,7 +559,6 @@ class BaseConfig(dict):
         Get the user configured value of a jail configuration property.
 
         The lookup order of such values is:
-            - native attributes
             - special properties
             - _get_{key} methods
             - plain data keys (without special processing)

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -517,7 +517,7 @@ class BaseConfig(dict):
             if is_existing is True:
                 return self.special_properties.get_or_create(key)
             elif is_resource_limit is True:
-                return None
+                raise KeyError(f"Resource-Limit unconfigured: {key}")
 
         # data with mappings
         method_name = f"_get_{key}"

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -115,7 +115,6 @@ class BaseConfig(dict):
                 Passed to __setitem__
 
         """
-        Data = ioc.Config.Data.Data
         if isinstance(data, dict) and not isinstance(data, Data):
             data = ioc.Config.Data.Data(dict(data))
         keys = data.keys()

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -528,18 +528,24 @@ class BaseConfig(dict):
 
     def _get_data(
         self,
-        key: str,
-        data: typing.Optional[typing.Dict[str, typing.Any]]=None
+        key: str
     ) -> typing.Any:
-        data = self.data if (data is None) else data
-        if "." not in key:
-            if key in data.keys():
-                return data[key]
+        data = self.data
+        keys = data.keys()
+        while True:
+            if "." not in key:
+                if key in keys:
+                    return data[key]
+                else:
+                    raise KeyError(f"User property not found: {key}")
             else:
-                raise KeyError(f"User defined property not found: {key}")
-        else:
-            current_key, rest_key = key.split(".", maxsplit=1)
-            return self._get_data(rest_key, data[current_key])
+                current, key = key.split(".", maxsplit=1)
+                if current not in keys:
+                    raise KeyError(f"User property not found: {current}")
+                data = data[current]
+                if isinstance(data, dict) is False:
+                    raise KeyError(f"User property is not nested: {current}")
+                keys = data.keys()
 
     def get(
         self,

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -739,6 +739,7 @@ class BaseConfig(dict):
         return (key == "user") or (key.startswith("user.") is True)
 
     def _is_known_property(self, key: str) -> bool:
+        """Return True when the key is a known config property."""
         if key in ioc.Config.Jail.Defaults.DEFAULTS.keys():
             return True  # key is default
         if f"_set_{key}" in dict.__dir__(self):

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -532,10 +532,6 @@ class BaseConfig(dict):
         """Triggered when a special property was updated."""
         self.data[name] = str(self.special_properties[name])
 
-        if (name == "ip6_addr") and (self.jail is not None):
-            rc_conf = self.jail.rc_conf
-            rc_conf["rtsold_enable"] = "accept_rtadv" in str(self["ip6_addr"])
-
     def attach_special_property(
         self,
         name: str,

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -653,8 +653,7 @@ class BaseConfig(dict):
         """
         hash_before: typing.Any
         hash_after: typing.Any
-
-        existed_before = (key in self) is True
+        existed_before = (key in self.keys()) is True
 
         try:
             hash_before = str(self._getitem_user(key)).__hash__()
@@ -663,7 +662,7 @@ class BaseConfig(dict):
 
         self.__setitem__(key, value, skip_on_error=skip_on_error)  # noqa: T484
 
-        exists_after = key in self.keys()
+        exists_after = (key in self.keys()) is True
 
         try:
             hash_after = str(self._getitem_user(key)).__hash__()

--- a/ioc/Config/Jail/BaseConfig.py
+++ b/ioc/Config/Jail/BaseConfig.py
@@ -726,11 +726,9 @@ class BaseConfig(dict):
     @property
     def all_properties(self) -> typing.List[str]:
         """Return a list of config object attributes."""
-        properties: typing.Set[str] = set()
-        properties = properties.union(self.keys())
+        properties: typing.Set[str] = set(self.keys())
         special_properties = ioc.Config.Jail.Properties.properties
-        properties = properties.union(special_properties)
-        return list(properties)
+        return list(properties.union(special_properties))
 
     def _key_is_mac_config(self, key: str, explicit: bool=False) -> bool:
         fragments = key.rsplit("_", maxsplit=1)

--- a/ioc/Config/Jail/Defaults.py
+++ b/ioc/Config/Jail/Defaults.py
@@ -136,7 +136,7 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
     def __getitem__(self, key: str) -> typing.Any:
         """Return a user provided value or the hardcoded default."""
         try:
-            return self.user_data.__getitem__(key)
+            return self._getitem_user(key)
         except KeyError:
             pass
 

--- a/ioc/Config/Jail/Defaults.py
+++ b/ioc/Config/Jail/Defaults.py
@@ -133,6 +133,16 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
         for key in data:
             self.user_data[key] = data[key]
 
+    def _getitem_special_property(
+        self,
+        key: str,
+        data: ioc.Config.Data.Data
+    ) -> ioc.Config.Jail.Properties.Property:
+        try:
+            return super()._getitem_special_property(key, data)
+        except KeyError:
+            return super()._getitem_special_property(key, DEFAULTS)
+
     def __getitem__(self, key: str) -> typing.Any:
         """Return a user provided value or the hardcoded default."""
         try:
@@ -141,6 +151,10 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
             pass
 
         return self.getitem_default(key)
+
+    def __contains__(self, key: typing.Any) -> bool:
+        """Return true if the storage or hardcoded defaults contain the key."""
+        return ((key in self.user_data) or (key in DEFAULTS)) is True
 
     def getitem_default(self, key: str) -> typing.Any:
         """Return the interpreted hardcoded default value."""

--- a/ioc/Config/Jail/Defaults.py
+++ b/ioc/Config/Jail/Defaults.py
@@ -136,10 +136,14 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
     def __getitem__(self, key: str) -> typing.Any:
         """Return a user provided value or the hardcoded default."""
         try:
-            return self._getitem_user(key)
+            return super().__getitem__(key)
         except KeyError:
             pass
 
+        return self.getitem_default(key)
+
+    def getitem_default(self, key: str) -> typing.Any:
+        """Return the interpreted hardcoded default value."""
         try:
             return DEFAULTS.__getitem__(key)
         except KeyError:

--- a/ioc/Config/Jail/Defaults.py
+++ b/ioc/Config/Jail/Defaults.py
@@ -139,11 +139,12 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
             return self.user_data.__getitem__(key)
         except KeyError:
             pass
-        return DEFAULTS.__getitem__(key)
 
-    def __setitem__(self, key: str, value: typing.Any) -> None:
-        """Set a user provided default setting."""
-        self.user_data.__setitem__(key, value)
+        try:
+            return DEFAULTS.__getitem__(key)
+        except KeyError:
+            if self.special_properties.is_special_property(key):
+                return None
 
     def __delitem__(self, key: str) -> None:
         """Remove a user provided default setting."""

--- a/ioc/Config/Jail/Defaults.py
+++ b/ioc/Config/Jail/Defaults.py
@@ -29,25 +29,97 @@ import ioc.helpers_object
 import ioc.Config.Data
 import ioc.Config.Jail.BaseConfig
 
+DEFAULTS = ioc.Config.Data.Data({
+    "id": None,
+    "release": None,
+    "boot": False,
+    "priority": 0,
+    "legacy": False,
+    "priority": 0,
+    "depends": [],
+    "basejail": False,
+    "basejail_type": "nullfs",
+    "clonejail": False,
+    "defaultrouter": None,
+    "defaultrouter6": None,
+    "mac_prefix": "02ff60",
+    "vnet": False,
+    "interfaces": [],
+    "vnet_interfaces": [],
+    "ip4": "new",
+    "ip4_saddrsel": 1,
+    "ip4_addr": None,
+    "ip6": "new",
+    "ip6_saddrsel": 1,
+    "ip6_addr": None,
+    "resolver": "/etc/resolv.conf",
+    "host_hostuuid": None,
+    "host_hostname": None,
+    "host_domainname": None,
+    "devfs_ruleset": 4,
+    "enforce_statfs": 2,
+    "children_max": 0,
+    "allow_set_hostname": 1,
+    "allow_sysvipc": 0,
+    "allow_raw_sockets": 0,
+    "allow_chflags": 0,
+    "allow_mount": 0,
+    "allow_mount_devfs": 0,
+    "allow_mount_nullfs": 0,
+    "allow_mount_procfs": 0,
+    "allow_mount_fdescfs": 0,
+    "allow_mount_zfs": 0,
+    "allow_mount_tmpfs": 0,
+    "allow_quotas": 0,
+    "allow_socket_af": 0,
+    "rlimits": None,
+    "sysvmsg": "new",
+    "sysvsem": "new",
+    "sysvshm": "new",
+    "exec_clean": 1,
+    "exec_fib": 1,
+    "exec_prestart": None,
+    "exec_created": None,
+    "exec_start": "/bin/sh /etc/rc",
+    "exec_poststart": None,
+    "exec_prestop": None,
+    "exec_stop": "/bin/sh /etc/rc.shutdown",
+    "exec_poststop": None,
+    "exec_jail_user": "root",
+    "exec_timeout": "600",
+    "stop_timeout": "30",
+    "mount_procfs": "0",
+    "mount_devfs": "1",
+    "mount_fdescfs": "0",
+    "securelevel": "2",
+    "tags": [],
+    "template": False,
+    "jail_zfs": False,
+    "jail_zfs_dataset": None,
+    "provisioning": {
+        "method": None,
+        "source": None,
+        "rev": "master"
+    }
+})
+
 
 class DefaultsUserData(dict):
     """Data-structure of default configuration data."""
 
     user_data: ioc.Config.Data.Data
-    defaults: ioc.Config.Data.Data  # noqa: E704
 
     def __init__(
         self,
         defaults: typing.Dict[str, typing.Any]={}
     ) -> None:
-        self.defaults = ioc.Config.Data.Data(defaults)
         self.user_data = ioc.Config.Data.Data()
 
     def __getitem__(self, key: str) -> typing.Any:
         """Return a user provided value or the hardcoded default."""
         if key in self.user_data.keys():
             return self.user_data.__getitem__(key)
-        return self.defaults.__getitem__(key)
+        return DEFAULTS.__getitem__(key)
 
     def __setitem__(self, key: str, value: typing.Any) -> None:
         """Set a user provided default setting."""
@@ -59,7 +131,7 @@ class DefaultsUserData(dict):
 
     def __iter__(self) -> typing.Iterator[str]:
         """Iterate over all default properties."""
-        return iter(self.user_properties.union(self.defaults.keys()))
+        return iter(self.user_properties.union(DEFAULTS.keys()))
 
     def __len__(self) -> int:
         """Return the number of default config properties."""
@@ -69,7 +141,7 @@ class DefaultsUserData(dict):
         """List all default property keys."""
         return typing.cast(
             typing.KeysView[str],
-            list(self.user_properties.union(self.defaults.keys()))
+            list(self.user_properties.union(DEFAULTS.keys()))
         )
 
     @property
@@ -91,89 +163,12 @@ class JailConfigDefaults(ioc.Config.Jail.BaseConfig.BaseConfig):
 
     _data: DefaultsUserData
 
-    DEFAULTS: dict = {
-        "id": None,
-        "release": None,
-        "boot": False,
-        "priority": 0,
-        "legacy": False,
-        "priority": 0,
-        "depends": [],
-        "basejail": False,
-        "basejail_type": "nullfs",
-        "clonejail": False,
-        "defaultrouter": None,
-        "defaultrouter6": None,
-        "mac_prefix": "02ff60",
-        "vnet": False,
-        "interfaces": [],
-        "vnet_interfaces": [],
-        "ip4": "new",
-        "ip4_saddrsel": 1,
-        "ip4_addr": None,
-        "ip6": "new",
-        "ip6_saddrsel": 1,
-        "ip6_addr": None,
-        "resolver": "/etc/resolv.conf",
-        "host_hostuuid": None,
-        "host_hostname": None,
-        "host_domainname": None,
-        "devfs_ruleset": 4,
-        "enforce_statfs": 2,
-        "children_max": 0,
-        "allow_set_hostname": 1,
-        "allow_sysvipc": 0,
-        "allow_raw_sockets": 0,
-        "allow_chflags": 0,
-        "allow_mount": 0,
-        "allow_mount_devfs": 0,
-        "allow_mount_nullfs": 0,
-        "allow_mount_procfs": 0,
-        "allow_mount_fdescfs": 0,
-        "allow_mount_zfs": 0,
-        "allow_mount_tmpfs": 0,
-        "allow_quotas": 0,
-        "allow_socket_af": 0,
-        "rlimits": None,
-        "sysvmsg": "new",
-        "sysvsem": "new",
-        "sysvshm": "new",
-        "exec_clean": 1,
-        "exec_fib": 1,
-        "exec_prestart": None,
-        "exec_created": None,
-        "exec_start": "/bin/sh /etc/rc",
-        "exec_poststart": None,
-        "exec_prestop": None,
-        "exec_stop": "/bin/sh /etc/rc.shutdown",
-        "exec_poststop": None,
-        "exec_jail_user": "root",
-        "exec_timeout": "600",
-        "stop_timeout": "30",
-        "mount_procfs": "0",
-        "mount_devfs": "1",
-        "mount_fdescfs": "0",
-        "securelevel": "2",
-        "tags": [],
-        "template": False,
-        "jail_zfs": False,
-        "jail_zfs_dataset": None,
-        "provisioning": {
-            "method": None,
-            "source": None,
-            "rev": "master"
-        }
-    }
-
     def __init__(
         self,
         logger: typing.Optional['ioc.Logger.Logger']=None
     ) -> None:
-
-        self.logger = ioc.helpers_object.init_logger(self, logger)
-        self._data = DefaultsUserData(
-            defaults=self.DEFAULTS
-        )
+        self._data = DefaultsUserData()
+        super().__init__(logger=logger)
 
     @property
     def data(self) -> DefaultsUserData:

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -37,7 +37,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
     legacy: bool = False
     jail: typing.Optional['ioc.Jail.JailGenerator']
     data: dict = {}
-    ignore_host_defaults: bool = False
+    ignore_host_defaults: bool
 
     def __init__(
         self,
@@ -47,6 +47,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
         host: typing.Optional['ioc.Host.HostGenerator']=None
     ) -> None:
 
+        self.ignore_host_defaults = False
         ioc.Config.Jail.BaseConfig.BaseConfig.__init__(
             self,
             logger=logger

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -59,10 +59,10 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
     def update_special_property(self, name: str) -> None:
         """Triggered when a special property was updated."""
         super().update_special_property(name)
-
         if (name == "ip6_addr") and (self.jail is not None):
             rc_conf = self.jail.rc_conf
-            rc_conf["rtsold_enable"] = "accept_rtadv" in str(self["ip6_addr"])
+            ip6_networks = self.special_properties[name].networks
+            rc_conf["rtsold_enable"] = "accept_rtadv" in ip6_networks
 
     def _get_host_hostname(self) -> str:
         try:

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -91,16 +91,16 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
         return key.startswith("user.") is True
 
     def _is_known_property(self, key: str) -> bool:
-        key_is_default = key in self.host.defaults.config.keys()
-        key_is_setter = f"_set_{key}" in dict.__dir__(self)
-        key_is_special = key in ioc.Config.Jail.Properties.properties
-        return any([
-            key_is_default,
-            key_is_setter,
-            key_is_special,
-            self._key_is_mac_config(key),
-            self._is_user_property(key)
-        ]) is True
+        if key in self.host.defaults.config.keys():
+            return True  # key is default
+        if  f"_set_{key}" in dict.__dir__(self):
+            return True  # key is setter
+        if key in ioc.Config.Jail.Properties.properties:
+            return True  # key is special property
+        if self._key_is_mac_config(key) is True:
+            return True  # nic mac config property
+        if self._is_user_property(key) is True:
+            return True  # user.* property
 
     def __setitem__(
         self,

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -32,7 +32,11 @@ BaseConfig = ioc.Config.Jail.BaseConfig.BaseConfig
 
 
 class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
-    """The configuration of a Jail or other LaunchableResource."""
+    """
+    The configuration of a Jail or other LaunchableResource.
+
+    In extend to a BasicConfig a JailConfig 
+    """
 
     legacy: bool = False
     jail: typing.Optional['ioc.Jail.JailGenerator']
@@ -75,20 +79,6 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
 
     def _get_legacy(self) -> bool:
         return self.legacy
-
-    def __setitem__(
-        self,
-        key: str,
-        value: typing.Any,
-        skip_on_error: bool=False
-    ) -> None:
-        """Set a configuration value."""
-        BaseConfig.__setitem__(
-            self,
-            key=key,
-            value=value,
-            skip_on_error=skip_on_error
-        )
 
     def __getitem__(self, key: str) -> typing.Any:
         """Get the value of a configuration argument or its default."""

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -56,6 +56,14 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
         self.host = ioc.helpers_object.init_host(self, host)
         self.jail = jail
 
+    def update_special_property(self, name: str) -> None:
+        """Triggered when a special property was updated."""
+        super().update_special_property(name)
+
+        if (name == "ip6_addr") and (self.jail is not None):
+            rc_conf = self.jail.rc_conf
+            rc_conf["rtsold_enable"] = "accept_rtadv" in str(self["ip6_addr"])
+
     def _get_host_hostname(self) -> str:
         try:
             return str(self.data["host_hostname"])

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -35,7 +35,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
     """
     The configuration of a Jail or other LaunchableResource.
 
-    In extend to a BasicConfig a JailConfig 
+    In extend to a BaseConfig a JailConfig is related to a Jail.
     """
 
     legacy: bool = False

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -37,7 +37,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
     legacy: bool = False
     jail: typing.Optional['ioc.Jail.JailGenerator']
     data: dict = {}
-    ignore_host_defaults: bool
+    ignore_user_defaults: bool
 
     def __init__(
         self,
@@ -47,7 +47,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
         host: typing.Optional['ioc.Host.HostGenerator']=None
     ) -> None:
 
-        self.ignore_host_defaults = False
+        self.ignore_user_defaults = False
         ioc.Config.Jail.BaseConfig.BaseConfig.__init__(
             self,
             logger=logger
@@ -138,7 +138,7 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
         try:
             return super().__getitem__(key)
         except KeyError:
-            if self.ignore_host_defaults is True:
+            if self.ignore_user_defaults is True:
                 raise
             pass
 

--- a/ioc/Config/Jail/JailConfig.py
+++ b/ioc/Config/Jail/JailConfig.py
@@ -107,6 +107,13 @@ class JailConfig(ioc.Config.Jail.BaseConfig.BaseConfig):
             # mixed with user defaults
             return self.host.defaults.config[key]
 
+    def get_raw(self, key: str) -> typing.Any:
+        """Return the raw data value or its raw default."""
+        self._require_known_config_property(key)
+        if key in self.data:
+            return self.data[key]
+        return self.host.defaults.config[key]
+
     @property
     def all_properties(self) -> list:
         """Return a list of all config properties (default and custom)."""

--- a/ioc/Config/Jail/Properties/Addresses.py
+++ b/ioc/Config/Jail/Properties/Addresses.py
@@ -262,7 +262,9 @@ class AddressesProp(dict):
             notify=False,
             skip_on_error=skip_on_error
         )
-        self.__notify()
+
+        if notify is True:
+            self.__notify()
 
     @property
     def networks(self) -> typing.List[str]:

--- a/ioc/Config/Jail/Properties/Interfaces.py
+++ b/ioc/Config/Jail/Properties/Interfaces.py
@@ -70,7 +70,10 @@ class InterfaceProp(dict):
             dict.__init__(self, data)
             return
 
-        nic_pairs = data.replace(",", " ").split(" ")
+        if isinstance(data, list):
+            nic_pairs = data
+        else:
+            nic_pairs = data.replace(",", " ").split(" ")
 
         if not all([(":" in nic_pair) for nic_pair in nic_pairs]):
             e = ioc.errors.InvalidJailConfigValue(

--- a/ioc/Config/Jail/Properties/Resolver.py
+++ b/ioc/Config/Jail/Properties/Resolver.py
@@ -79,7 +79,7 @@ class ResolverProp(collections.MutableSequence):
     @property
     def value(self) -> typing.Optional[str]:
         """Return the raw configuration string or None."""
-        value = self.config.data["resolver"]
+        value = self.config.get_raw("resolver")
         try:
             ioc.helpers.parse_none(value, self.none_matches)
             return None
@@ -162,7 +162,7 @@ class ResolverProp(collections.MutableSequence):
                 )
         elif method == "skip":
             # directly set config property
-            self.config.data["resolver"] = None
+            self.config.get_raw["resolver"] = None
         else:
             if isinstance(value, str):
                 self.append(str(value), notify=False)

--- a/ioc/Config/Jail/Properties/ResourceLimit.py
+++ b/ioc/Config/Jail/Properties/ResourceLimit.py
@@ -171,9 +171,8 @@ class ResourceLimitProp(ResourceLimitValue):
         if property_name not in properties:
             raise ioc.errors.ResourceLimitUnknown(logger=self.logger)
 
-        self.__update_from_config()
-
         ResourceLimitValue.__init__(self)
+        self.__update_from_config()
 
     def _parse_resource_limit(self, value: str) -> typing.Tuple[
         typing.Optional[str],

--- a/ioc/Config/Jail/Properties/ResourceLimit.py
+++ b/ioc/Config/Jail/Properties/ResourceLimit.py
@@ -134,6 +134,10 @@ class ResourceLimitValue:
         else:
             return self.limit_string
 
+    def __repr__(self) -> str:
+        """Return a string representation of the object."""
+        return f"<{self.__class__.__name__} {self.limit_string}>"
+
     @property
     def limit_string(self) -> str:
         """Return the limit string in rctl syntax."""
@@ -231,3 +235,8 @@ class ResourceLimitProp(ResourceLimitValue):
         if self.config is None:
             return
         self.config.update_special_property(self.property_name)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the object."""
+        class_name = self.__class__.__name__
+        return f"<{class_name} {self.property_name}={self.limit_string}>"

--- a/ioc/Config/Jail/Properties/ResourceLimit.py
+++ b/ioc/Config/Jail/Properties/ResourceLimit.py
@@ -183,11 +183,11 @@ class ResourceLimitProp(ResourceLimitValue):
 
     def __update_from_config(self) -> None:
         name = self.property_name
-        if (self.config is None) or (name not in self.config.data.keys()):
+        if (self.config is None) or (name not in self.config):
             self.set(None)
         else:
             self.set(
-                self.config.data[self.property_name]
+                self.config.get_raw(self.property_name)
             )
 
     def set(
@@ -204,8 +204,8 @@ class ResourceLimitProp(ResourceLimitValue):
         if data is None:
             name = self.property_name
             config = self.config
-            if (config is not None) and (name in config.data.keys()):
-                config.data.__delitem__(name)
+            if (config is not None) and (name in config):
+                del config[name]
             amount = None
             action = None
             per = None

--- a/ioc/Jail.py
+++ b/ioc/Jail.py
@@ -222,12 +222,11 @@ class JailResource(
     def get(self, key: str) -> typing.Any:
         """Get a config value from the jail or defer to its resource."""
         try:
-            out = self.jail.config[key]
-            return out
-        except KeyError:
+            return ioc.Resource.Resource.get(self, key)
+        except AttributeError:
             pass
 
-        return ioc.Resource.Resource.get(self, key)
+        return self.jail.config[key]
 
 
 class JailGenerator(JailResource):

--- a/ioc/Jail.py
+++ b/ioc/Jail.py
@@ -321,9 +321,7 @@ class JailGenerator(JailResource):
         self._relative_hook_script_dir = "/.iocage"
 
         if isinstance(data, str):
-            data = {
-                "id": data
-            }
+            data = dict(id=data)
 
         if "id" in data.keys():
             data["id"] = self._resolve_name(data["id"])

--- a/ioc/Jail.py
+++ b/ioc/Jail.py
@@ -2170,7 +2170,7 @@ class JailGenerator(JailResource):
 
         for prop in self.config.all_properties:
             prop_name = f"IOCAGE_{prop.replace('.', '_').upper()}"
-            jail_env[prop_name] = self.getstring(prop)
+            jail_env[prop_name] = str(self.config[prop])
 
         jail_env["IOCAGE_JAIL_PATH"] = self.root_dataset.mountpoint
         jail_env["IOCAGE_JID"] = str(self.jid)

--- a/ioc/Pkg.py
+++ b/ioc/Pkg.py
@@ -471,7 +471,7 @@ class Pkg:
             host=source_jail.host,
             dataset=source_jail.dataset
         )
-        temporary_jail.config.ignore_host_defaults = True
+        temporary_jail.config.ignore_user_defaults = True
         self.__mount_pkg_directory(temporary_jail)
 
         return temporary_jail

--- a/ioc/Resource.py
+++ b/ioc/Resource.py
@@ -412,4 +412,4 @@ class DefaultResource(Resource):
 
     def save(self) -> None:
         """Save changes to the default configuration."""
-        self._write_config(self.config.user_data)
+        self._write_config(self.config.user_data.nested)

--- a/ioc/Resource.py
+++ b/ioc/Resource.py
@@ -343,7 +343,7 @@ class Resource(metaclass=abc.ABCMeta):
         try:
             return self.__getattribute__(key)
         except AttributeError:
-            return None
+            raise
 
     def getstring(self, key: str) -> str:
         """

--- a/ioc/ResourceUpdater.py
+++ b/ioc/ResourceUpdater.py
@@ -141,7 +141,7 @@ class Updater:
                 dataset=self.resource.dataset
             )
             temporary_jail.config.file = "config_update.json"
-            temporary_jail.config.ignore_host_defaults = True
+            temporary_jail.config.ignore_user_defaults = True
 
             root_path = temporary_jail.root_path
             destination_dir = f"{root_path}{self.local_release_updates_dir}"

--- a/ioc/errors.py
+++ b/ioc/errors.py
@@ -486,19 +486,17 @@ class DefaultConfigNotFound(IocageException, FileNotFoundError):
         IocageException.__init__(self, message=msg, logger=logger)
 
 
-class UnknownJailConfigProperty(IocageException, KeyError):
+class UnknownConfigProperty(IocageException, KeyError):
     """Raised when a unknown jail config property was used."""
 
     def __init__(
         self,
         key: str,
-        jail: 'ioc.Jail.JailGenerator',
         logger: typing.Optional['ioc.Logger.Logger']=None,
         level: str="error"
     ) -> None:
         msg = (
-            f"The config property '{key}' "
-            f"of jail '{jail.humanreadable_name}' is unknown."
+            f"The config property '{key}' is unknown"
         )
         IocageException.__init__(self, message=msg, logger=logger, level=level)
 


### PR DESCRIPTION
fixes #601 

- refactor and simplify Config classes 
- provide special config properties of defaults as property instance
- access dicts of nested config properties
- ignore_source_config property has desired effect and is renamed
- optimize config handling performance