### PR TITLE
Sanitize internal JailConfig data types

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -683,6 +683,8 @@ class BaseConfig(dict):
         try:
             hash_before = str(self.__getitem__(key)).__hash__()
         except Exception:
+            if existed_before is True:
+                raise
             hash_before = None
 
         self.__setitem__(key, value, skip_on_error=skip_on_error)  # noqa: T484

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -250,7 +250,7 @@ class BaseConfig(dict):
         return int(self.data["priority"])
 
     def _set_priority(self, value: typing.Union[int, str]) -> None:
-        self.data["priority"] = str(value)
+        self.data["priority"] = str(libioc.helpers.parse_int(value))
 
     # legacy support
     def _get_tag(self) -> typing.Optional[str]:

--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -26,7 +26,6 @@
 import typing
 
 import libioc.helpers_object
-import libioc.Config.Jail.Defaults
 import libioc.Config.Jail.BaseConfig
 
 BaseConfig = libioc.Config.Jail.BaseConfig.BaseConfig
@@ -97,45 +96,6 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
         else:
             # mixed with user defaults
             return self.host.defaults.config[key]
-
-    def __setitem__(  # noqa: T400
-        self,
-        key: str,
-        value: typing.Any,
-        skip_on_error: bool=False
-    ) -> None:
-        """
-        Normalize and set values to the configuration.
-
-        The type if the value defined in hardcoded defaults constraints the
-        accepted input.
-        """
-        super().__setitem__(
-            key=key,
-            value=self.__sanitize_value(key, value),
-            skip_on_error=skip_on_error
-        )
-
-    def __sanitize_value(self, key: str, value: typing.Any) -> typing.Any:
-        """Sanitize the value type to the same found in hardcoded defaults."""
-        try:
-            default_type = self.__get_default_type(key)
-        except KeyError:
-            return value
-
-        if default_type == list:
-            return ioc.helpers.parse_list(value)
-        elif default_type == str:
-            return str(value)
-        elif default_type == bool:
-            return ioc.helpers.parse_bool(value)
-        elif default_type == int:
-            return ioc.helpers.parse_int(value)
-
-        return value
-
-    def __get_default_type(self, key: str) -> typing.Optional[type]:
-        return type(ioc.Config.Jail.Defaults.DEFAULTS[key])
 
     def get_raw(self, key: str) -> typing.Any:
         """Return the raw data value or its raw default."""

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -260,6 +260,37 @@ def parse_bool(data: typing.Optional[typing.Union[str, bool]]) -> bool:
     raise TypeError("Value is not a boolean")
 
 
+def parse_int(data: typing.Optional[typing.Union[str, int]]) -> int:
+    """
+    Try to parse integer from strings.
+
+    On success, it returns the parsed integer on failure it raises a TypeError.
+
+    Usage:
+        >>> parse_int("-1")
+        -1
+        >>> parse_int(3)
+        3
+        >>> parse_int(None)
+        TypeError: None is not a number
+        >>> parse_int("invalid")
+        TypeError: Value is not an integer: invalid
+        >>> parse_int(5.0)
+        5
+        >>> parse_int(5.1)
+        TypeError: Value is not an integer: 5.1
+    """
+    if data is None:
+        raise TypeError("None is not a number")
+    try:
+        if isinstance(data, float) and (float(data).is_integer() is False):
+            raise ValueError
+        return int(data)
+    except ValueError:
+        pass
+    raise TypeError(f"Value is not an integer: {data}")
+
+
 def parse_user_input(
     data: typing.Optional[typing.Union[str, bool]]
 ) -> typing.Optional[typing.Union[str, bool]]:


### PR DESCRIPTION
When setting an item on a JailConfig object and it is a plain property stored in JailConfig.data, the hardcoded defaults data type is looked up and used to sanitize the input.

- Prevents setting invalid values
- Improved error message when failing because of an invalid type
- Proper types for JailConfig properties