### PR TITLE
JailConfig parameter vnet must be boolean

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -376,7 +376,7 @@ class BaseConfig(dict):
             raise ValueError(str(e))
 
     def _get_vnet(self) -> bool:
-        return libioc.helpers.parse_user_input(self.data["vnet"]) is True
+        return libioc.helpers.parse_bool(self.data["vnet"]) is True
 
     def _set_vnet(self, value: typing.Union[str, bool]) -> None:
         self.data["vnet"] = libioc.helpers.to_string(
@@ -610,6 +610,7 @@ class BaseConfig(dict):
                 return
 
             parsed_value = libioc.helpers.parse_user_input(value)
+
             setter_method_name = f"_set_{key}"
             if setter_method_name in object.__dir__(self):
                 setter_method = self.__getattribute__(setter_method_name)


### PR DESCRIPTION
Before this change it was possible to store arbitrary strings as VNET value. Since this is a boolean configuration property, it must be boolean on set.