### PR TITLE
Accept non-absolute path as fstab source

### DIFF
--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -68,8 +68,8 @@ class FstabLine(dict):
             self._escape("destination"),
             self.get("type", "nullfs"),
             self.get("options", "ro"),
-            self.get("dump", "0"),
-            self.get("passnum", "0")
+            str(self.get("freq", 0)),
+            str(self.get("passno", 0))
         ])
 
         if self["comment"] is not None:
@@ -92,7 +92,7 @@ class FstabLine(dict):
             dict.__setitem__(self, key, FstabFsSpec(value))
         elif key == "destination":
             dict.__setitem__(self, key, libioc.Types.AbsolutePath(value))
-        elif key in ["type", "options", "dump", "passnum", "comment"]:
+        elif key in ["type", "options", "freq", "passno", "comment"]:
             dict.__setitem__(self, key, value)
         else:
             raise KeyError(f"Invalid FstabLine key: {key}")
@@ -299,8 +299,8 @@ class Fstab(
                 "destination": libioc.Types.AbsolutePath(destination),
                 "type": fragments[2],
                 "options": fragments[3],
-                "dump": fragments[4],
-                "passnum": fragments[5],
+                "freq": int(fragments[4]),
+                "passno": int(fragments[5]),
                 "comment": comment
             })
 
@@ -354,8 +354,8 @@ class Fstab(
         destination: str,
         type: str="nullfs",
         options: str="ro",
-        dump: str="0",
-        passnum: str="0",
+        freq: int=0,
+        passno: int=0,
         comment: typing.Optional[str]=None,
         replace: bool=False,
         auto_create_destination: bool=False,
@@ -371,8 +371,8 @@ class Fstab(
             "destination": destination,
             "type": type,
             "options": options,
-            "dump": dump,
-            "passnum": passnum,
+            "freq": freq,
+            "passno": passno,
             "comment": comment
         })
 
@@ -506,8 +506,8 @@ class Fstab(
             ),
             options="ro",
             type="nullfs",
-            dump="0",
-            passnum="0",
+            freq=0,
+            passno=0,
             comment=self.AUTO_COMMENT_IDENTIFIER
         ))]
 
@@ -543,8 +543,8 @@ class Fstab(
                 "destination": destination,
                 "type": "nullfs",
                 "options": "ro",
-                "dump": "0",
-                "passnum": "0",
+                "freq": 0,
+                "passno": 0,
                 "comment": self.AUTO_COMMENT_IDENTIFIER
             }))
 

--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -35,6 +35,18 @@ import libioc.Types
 import libioc.Config.Jail.File
 
 
+class FstabFsSpec(libioc.Types.AbsolutePath):
+    """Enforces an AbsolutePath or special device name."""
+
+    PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9]*$")
+
+    def __init__(self, sequence: str) -> None:
+        if self.PATTERN.match(sequence) is not None:
+            self = str(sequence)  # type: ignore
+        else:
+            super().__init__(sequence)
+
+
 class FstabLine(dict):
     """Model a line of an fstab file."""
 
@@ -76,20 +88,10 @@ class FstabLine(dict):
         value: typing.Union[str, libioc.Types.AbsolutePath]
     ) -> None:
         """Set an item of the FstabLine."""
-        _type = None
         if key == "source":
-            _type = libioc.Types.Path
+            dict.__setitem__(self, key, FstabFsSpec(value))
         elif key == "destination":
-            _type = libioc.Types.AbsolutePath
-
-        if _type is not None:  # source or destination
-            if isinstance(value, str) is True:
-                absolute_path = _type(value)
-            elif isinstance(value, _type) is True:
-                absolute_path = value
-            else:
-                raise ValueError("String or AbsolutePath expected")
-            dict.__setitem__(self, key, absolute_path)
+            dict.__setitem__(self, key, libioc.Types.AbsolutePath(value))
         elif key in ["type", "options", "dump", "passnum", "comment"]:
             dict.__setitem__(self, key, value)
         else:

--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -76,10 +76,16 @@ class FstabLine(dict):
         value: typing.Union[str, libioc.Types.AbsolutePath]
     ) -> None:
         """Set an item of the FstabLine."""
-        if (key == "source") or (key == "destination"):
+        _type = None
+        if key == "source":
+            _type = libioc.Types.Path
+        elif key == "destination":
+            _type = libioc.Types.AbsolutePath
+
+        if _type is not None:  # source or destination
             if isinstance(value, str) is True:
-                absolute_path = libioc.Types.AbsolutePath(value)
-            elif isinstance(value, libioc.Types.AbsolutePath) is True:
+                absolute_path = _type(value)
+            elif isinstance(value, _type) is True:
                 absolute_path = value
             else:
                 raise ValueError("String or AbsolutePath expected")
@@ -287,7 +293,7 @@ class Fstab(
                 ])
 
             new_line = FstabLine({
-                "source": libioc.Types.AbsolutePath(source),
+                "source": libioc.Types.Path(source),
                 "destination": libioc.Types.AbsolutePath(destination),
                 "type": fragments[2],
                 "options": fragments[3],

--- a/libioc/Types.py
+++ b/libioc/Types.py
@@ -27,18 +27,43 @@ import typing
 import re
 
 
-class AbsolutePath(str):
+class Path(str):
     """Wrapper Type for ensuring a `str` matches a Unix Path."""
 
-    unix_path = re.compile(r"/([^/\0]+/*)+")
+    blacklist = re.compile(
+        r"(\/\/)|(\/\.\.)|(\.\.\/)|(\n)|(\r)|(^\.+$)",
+        re.MULTILINE
+    )
 
     def __init__(
-            self,
-            sequence: str
+        self,
+        sequence: str
     ) -> None:
-        if self.unix_path.fullmatch(sequence) is None:
-            raise TypeError(f"Invalid value for AbsolutePath: {sequence}")
+        if isinstance(sequence, str) is False:
+            raise TypeError("Path must be a string")
+
+        if len(self.blacklist.findall(sequence)) > 0:
+            raise TypeError(f"Illegal path: {sequence}")
+
         self = sequence  # type: ignore
+
+
+class AbsolutePath(Path):
+    """Wrapper Type for ensuring a `str` matches an absolute Unix Path."""
+
+    def __init__(
+        self,
+        sequence: str
+    ) -> None:
+        if isinstance(sequence, str) is False:
+            raise TypeError("AbsolutePath must be a string or Path")
+
+        if str(sequence).startswith("/") is False:
+            raise TypeError(
+                f"Expected AbsolutePath to begin with /, but got: {sequence}"
+            )
+
+        super().__init__(sequence)
 
 
 class UserInput:


### PR DESCRIPTION
fixes #613

A Fstab source path does not necessarily require to be absolute (begin with a `/`).

https://github.com/iocage/iocage/issues/806 describes an fstab file that defines a tmpfs mountpoint within a jail. Even though this is a bad idea (because it bypasses jail resource limits and can lead to confusion of services within the jail), reading and creating fstab files should be possible using this library.

This changes enhance path verification and add the ability to use relative paths as fstab source path.