### PR TITLE
Fix pkg install and freebsd update

### DIFF
--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -471,7 +471,7 @@ class Pkg:
             host=source_jail.host,
             dataset=source_jail.dataset
         )
-        temporary_jail.config.ignore_user_defaults = True
+        temporary_jail.config.ignore_source_config = True
         self.__mount_pkg_directory(temporary_jail)
 
         return temporary_jail

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -141,7 +141,7 @@ class Updater:
                 dataset=self.resource.dataset
             )
             temporary_jail.config.file = "config_update.json"
-            temporary_jail.config.ignore_user_defaults = True
+            temporary_jail.config.ignore_source_config = True
 
             root_path = temporary_jail.root_path
             destination_dir = f"{root_path}{self.local_release_updates_dir}"


### PR DESCRIPTION
during the review of #602, we decided to rename the Jail class variable
`ignore_user_defaults` to `ignore_source_config`, so as to not be confused
with `user.*` properties.

This was, however, not done consequentially throughout the PR, so that
`ioc pkg` and `ioc update` were still broken.

This PR fixes that.