### PR TITLE
handle config property None-values as such

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -581,7 +581,7 @@ class BaseConfig(dict):
             return get_method()
 
         # plain data attribute
-        return self.data[key]
+        return libioc.helpers.parse_user_input(self.data[key])
 
     def __delitem__(self, key: str) -> None:
         """Delete a setting from the configuration."""
@@ -637,6 +637,12 @@ class BaseConfig(dict):
             default_type = self.__get_default_type(key)
         except KeyError:
             return value
+
+        try:
+            # allow any time to be None
+            return libioc.helpers.parse_none(value)
+        except ValueError:
+            pass
 
         if default_type == list:
             return libioc.helpers.parse_list(value)

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -163,7 +163,9 @@ def parse_none(
     none_matches: typing.List[str]=["none", "-", ""]
 ) -> None:
     """Raise if the input does not translate to None."""
-    if (data is None) or (data in none_matches):
+    if data is None:
+        return None
+    if isinstance(data, str) and (data.lower() in none_matches):
         return None
     raise TypeError("Value is not None")
 
@@ -308,6 +310,8 @@ def parse_user_input(
     'notfalse'
     >>> parse_user_input(8.4)
     8.4
+    >>> parse_user_input(dict(ioc=123))
+    {'ioc': 123}
     """
     try:
         return parse_bool(data)


### PR DESCRIPTION
When a jail config parameter value was sanitized (#609), the data type was taken from the defaults configuration. Because different values for defaults such as `exec_prestart` (`None`) and `exec_start` (`str`) were used, the sanitization resulted in different values when setting each to `None`.

This PR solves the issue by:
- always piping values from `BaseConfig.data.__getitem__` through `libioc.helpers.parse_user_input`
- allowing each config property to be set to None