### PR TITLE
catch TypeError instead of ValueError when parsing input for none values

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -641,7 +641,7 @@ class BaseConfig(dict):
         try:
             # allow any time to be None
             return libioc.helpers.parse_none(value)
-        except ValueError:
+        except TypeError:
             pass
 
         if default_type == list:


### PR DESCRIPTION
Fixes an issue when setting Jail Config properties that do not parse to None.