### PR TITLE
Puppet (apply) provisioning plugin

### DIFF
--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -642,7 +642,7 @@ class Fstab(collections.MutableSequence):
             # find FstabAutoPlaceholderLine instead
             line = list(filter(
                 lambda x: isinstance(x, FstabAutoPlaceholderLine),
-                self._line
+                self._lines
             ))[0]
             real_index = self._lines.index(line)
         else:

--- a/libioc/Config/Jail/File/__init__.py
+++ b/libioc/Config/Jail/File/__init__.py
@@ -30,36 +30,6 @@ import libioc.helpers
 import libioc.helpers_object
 import libioc.LaunchableResource
 
-
-class ResourceConfig:
-    """Shared abstract code between various config files in a resource."""
-
-    def _require_path_relative_to_resource(
-        self,
-        filepath: str,
-        resource: 'libioc.LaunchableResource.LaunchableResource'
-    ) -> None:
-
-        if self._is_path_relative_to_resource(filepath, resource) is False:
-            raise libioc.errors.SecurityViolationConfigJailEscape(
-                file=filepath
-            )
-
-    def _is_path_relative_to_resource(
-        self,
-        filepath: str,
-        resource: 'libioc.LaunchableResource.LaunchableResource'
-    ) -> bool:
-
-        real_resource_path = self._resolve_path(resource.dataset.mountpoint)
-        real_file_path = self._resolve_path(filepath)
-
-        return real_file_path.startswith(real_resource_path)
-
-    def _resolve_path(self, filepath: str) -> str:
-        return os.path.realpath(os.path.abspath(filepath))
-
-
 class ConfigFile(dict):
     """Abstraction of UCL file based config files in Resources."""
 
@@ -221,7 +191,7 @@ class ConfigFile(dict):
         return None
 
 
-class ResourceConfigFile(ConfigFile, ResourceConfig):
+class ResourceConfigFile(ConfigFile):
     """Abstraction of UCL file based config files in Resources."""
 
     def __init__(
@@ -238,8 +208,5 @@ class ResourceConfigFile(ConfigFile, ResourceConfig):
     def path(self) -> str:
         """Absolute path to the file."""
         path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
-        self._require_path_relative_to_resource(
-            filepath=path,
-            resource=self.resource
-        )
+        self.resource._require_relative_path(path)
         return os.path.abspath(path)

--- a/libioc/Config/Type/JSON.py
+++ b/libioc/Config/Type/JSON.py
@@ -53,6 +53,6 @@ class DatasetConfigJSON(
     libioc.Config.Dataset.DatasetConfig,
     ConfigJSON
 ):
-    """ResourceConfig in JSON format."""
+    """ConfigFile in JSON format."""
 
     pass

--- a/libioc/Config/Type/UCL.py
+++ b/libioc/Config/Type/UCL.py
@@ -52,6 +52,6 @@ class DatasetConfigUCL(
     libioc.Config.Dataset.DatasetConfig,
     ConfigUCL
 ):
-    """ResourceConfig in UCL format."""
+    """ConfigFile in UCL format."""
 
     pass

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -726,7 +726,7 @@ class JailGenerator(JailResource):
         self,
         commands: typing.Optional[typing.Union[str, typing.List[str]]],
         ignore_errors: bool=True,
-        jailed: bool=False,
+        jailed: bool=False,  # ToDo: remove unused argument
         write_env: bool=True
     ) -> typing.List[str]:
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -862,6 +862,7 @@ class JailGenerator(JailResource):
         raise NotImplementedError("_run_hook only supports start/stop")
 
     def _ensure_script_dir(self) -> None:
+        """Ensure that the launch scripts dir exists."""
         realpath = os.path.realpath(self.launch_script_dir)
         if realpath.startswith(self.dataset.mountpoint) is False:
             raise libioc.errors.SecurityViolationConfigJailEscape(

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -2175,6 +2175,14 @@ class JailGenerator(JailResource):
 
         jail_env["IOC_JAIL_PATH"] = self.root_dataset.mountpoint
         jail_env["IOC_JID"] = str(self.jid)
+        jail_env["PATH"] = ":".join((
+            "/sbin",
+            "/bin",
+            "/usr/sbin",
+            "/usr/bin",
+            "/usr/local/sbin",
+            "/usr/local/bin",
+        ))
 
         return jail_env
 

--- a/libioc/Provisioning/__init__.py
+++ b/libioc/Provisioning/__init__.py
@@ -28,6 +28,7 @@ import typing
 import libioc.errors
 import libioc.helpers
 import libioc.Provisioning.ix
+import libioc.Provisioning.puppet
 
 
 class Prototype:

--- a/libioc/Provisioning/__init__.py
+++ b/libioc/Provisioning/__init__.py
@@ -84,7 +84,8 @@ class Provisioner(Prototype):
 		self
 	) -> typing.Dict[str, Prototype]:
 		return dict(
-			ix=libioc.Provisioning.ix
+			ix=libioc.Provisioning.ix,
+			puppet=libioc.Provisioning.puppet
 		)
 
 	@property

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -114,7 +114,6 @@ class ControlRepoDefinition(dict):
                 "Source must be urllib.parse.ParseResult or absolute path"
             )
 
-
     @property
     def pkgs(self) -> typing.List[str]:
         """Return list of packages required for this Provisioning method."""
@@ -180,7 +179,7 @@ def provision(
     try:
         yield jailProvisioningAssetDownloadEvent.begin()
         pluginDefinition = ControlRepoDefinition(
-            url=urllib.parse.urlparse(self.source).geturl(),
+            source=urllib.parse.urlparse(self.source).geturl(),
             logger=self.jail.logger
         )
         yield jailProvisioningAssetDownloadEvent.end()
@@ -198,7 +197,7 @@ def provision(
         if not os.path.isdir(plugin_dataset_name):
             # only clone if it doesn't already exist
             git.Repo.clone_from(
-                pluginDefinition.url,
+                pluginDefinition.source,
                 plugin_dataset.mountpoint
             )
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -174,7 +174,7 @@ def provision(
         raise e
 
     if not (self.source.startswith('file://') or self.source.startswith('/')):
-        # clone control repo
+        mode = 'rw'  # we'll need to run r10k here..
         plugin_dataset_name = f"{self.jail.dataset.name}/puppet"
         plugin_dataset = self.zfs.get_or_create_dataset(
             plugin_dataset_name
@@ -189,12 +189,13 @@ def provision(
 
         mount_source = plugin_dataset.mountpoint
     else:
+        mode = 'ro'
         mount_source = self.source
 
     self.jail.fstab.new_line(
         source=mount_source,
         destination="/usr/local/etc/puppet",
-        options="rw",
+        options=mode,
         auto_create_destination=True,
         replace=True
     )

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -137,12 +137,12 @@ class ControlRepoDefinition(dict):
                     remote: {self.source}
             >EOF
 
-            r10k deploy environment -p
+            r10k deploy environment -pv
 
             """
 
         postinstall += """
-        puppet apply /usr/local/etc/puppet/environments/manifests/site.pp
+        puppet apply --debug {basedir}/manifests/site.pp
         """
         return postinstall
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -202,10 +202,6 @@ def provision(
     )
 
     try:
-        env = {
-            'PATH':
-            '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin'
-        }
         if self.source.remote is True:
 
             r10kDeployEvent = R10kDeployEvent(
@@ -231,7 +227,7 @@ def provision(
                     "deploy",
                     "environment",
                     "-pv"
-                ], env=env )
+                ])
             except Exception as e:
                 yield r10kDeployEvent.fail(e)
                 raise e
@@ -250,7 +246,7 @@ def provision(
                 "--logdest",
                 "syslog",
                 f"{puppet_env_dir}/production/manifests/site.pp"
-            ], env=env)
+            ])
             yield puppetApplyEvent.end()
         except Exception as e:
             yield puppetApplyEvent.fail(e)

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -148,27 +148,27 @@ def provision(
         ioc set \
             provisioning.method=puppet \
             provisioning.source=http://example.com/my/puppet-env \
-            provisioning.source.name=my-puppet-env \
+            provisioning.name=my-puppet-env \
             myjail
 
     """
     events = libioc.events
     jailProvisioningEvent = events.JailProvisioning(
         jail=self.jail,
-        event_scope=event_scope
+        scope=event_scope
     )
     yield jailProvisioningEvent.begin()
     _scope = jailProvisioningEvent.scope
     jailProvisioningAssetDownloadEvent = events.JailProvisioningAssetDownload(
         jail=self.jail,
-        event_scope=_scope
+        scope=_scope
     )
 
     # download / mount provisioning assets
     try:
         yield jailProvisioningAssetDownloadEvent.begin()
         pluginDefinition = ControlRepoDefinition(
-            name=self.source.name,
+            name=self.name,
             url=self.source,
             logger=self.jail.logger
         )

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2017-2019, Stefan Grönke, Igor Galić
+# Copyright (c) 2014-2018, ioc
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""ioc provisioner for use with `puppet apply`."""
+import typing
+import os.path
+import json
+import urllib.error
+import urllib.request
+import libzfs
+
+import git
+
+import libioc.errors
+import libioc.events
+import libioc.Pkg
+import libioc.Provisioning
+
+
+class ControlRepoUnavailableError(libioc.errors.IocException):
+    """Raised when the puppet control-repo is not available."""
+
+    def __init__(
+        self,
+        url: str,
+        reason: str,
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+        msg = f"Puppet control-repo '{url}' is not available: {reason}"
+        libioc.errors.IocException.__init__(
+            self,
+            message=msg,
+            logger=logger
+        )
+
+
+class ControlRepoDefinition(dict):
+    """Puppet control-repo definition."""
+
+    _url: str
+    _name: str
+    _pkgs: typing.List[str]
+
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        logger: 'libioc.Logger.Logger'
+    ) -> None:
+        self.logger = logger
+        self.url = url
+        self.name = name
+
+        _pkgs = ['puppet6']  # make this a Global Varialbe
+        if not (url.startswith('file://') or url.startswith('/')):
+            _pkgs += 'rubygem-r10k'
+
+    @property
+    def url(self) -> str:
+        """Return the Puppet Control-Repo URL."""
+        return str(self._url)
+
+    @property.setter
+    def url(self) -> str:
+        """Set the Puppet Control-Repo URL."""
+        return str(self._url)
+
+    @property
+    def name(self, value: str) -> str:
+        """Return the unique name for this Puppet Control-Repo URL."""
+        return self._name
+
+    @property.setter
+    def name(self, value: str) -> None:
+        """Set a unique name for this Puppet Control-Repo URL."""
+        self._name = value
+
+    @property
+    def pkgs(self, value: str) -> typing.List[str]:
+        """Return list of packages required for this Provisioning method."""
+        return self._pkgs
+
+    #@property.setter
+    #def pkgs(self, value: str) -> None:
+    #    """Set (list) of additional packagess required for this Puppet Control-Repo URL."""
+    #    self._pkgs += value
+
+
+def provision(
+    self: 'libioc.Provisioning.Prototype',
+    event_scope: typing.Optional['libioc.events.Scope']=None
+) -> typing.Generator['libioc.events.IocEvent', None, None]:
+    """
+    Provision the jail with Puppet apply using the supplied control-repo.
+
+    The repo can either be a filesystem path, or a http[s]/git URL.
+    If the repo is a filesystem path, it will be mounted appropriately.
+    If the repo is a URL, it will be setup with `r10k`.
+
+        ioc set provisioning.method=puppet provisioning.source=http://example.com/my/puppet-env myjail
+
+    """
+    events = libioc.events
+    jailProvisioningEvent = events.JailProvisioning(
+        jail=self.jail,
+        event_scope=event_scope
+    )
+    yield jailProvisioningEvent.begin()
+    _scope = jailProvisioningEvent.scope
+    jailProvisioningAssetDownloadEvent = events.JailProvisioningAssetDownload(
+        jail=self.jail,
+        event_scope=_scope
+    )
+
+    # download / mount provisioning assets
+    try:
+        yield jailProvisioningAssetDownloadEvent.begin()
+        pluginDefinition = ControlRepoDefinition(
+            self.source,
+            logger=self.jail.logger
+        )
+        yield jailProvisioningAssetDownloadEvent.end()
+    except Exception as e:
+        yield jailProvisioningAssetDownloadEvent.fail(e)
+        raise e
+
+    if not (self.source.startswith('file://') or self.source.startswith('/')):
+        # clone control repo
+        controlrepo_dataset_name = f"{self.jail.dataset.name}/puppet"
+        controlrepo_dataset = __get_empty_dataset(
+            control_repo_dataset_name, self.jail.zfs)
+
+        git.Repo.clone_from(
+            ControlRepoDefinition["url"],
+            plugin_dataset.mountpoint
+        )
+
+    self.jail.fstab.new_line(
+        source=plugin_dataset.mountpoint,
+        destination="/.puppet",
+        options="ro",
+        auto_create_destination=True,
+        replace=True
+    )
+    self.jail.fstab.save()
+
+    if "pkgs" in controlRepoDefinition.keys():
+        pkg_packages = list(controlRepoDefinition["pkgs"])
+    else:
+        pkg_packages = []
+
+    try:
+        pkg = libioc.Pkg.Pkg(
+            logger=self.jail.logger,
+            zfs=self.jail.zfs,
+            host=self.jail.host
+        )
+
+        if os.path.isfile(f"{plugin_dataset.mountpoint}/post_install.sh"):
+            postinstall = ["/.puppet/post_install.sh"]
+        else:
+            postinstall = []
+
+        yield from pkg.fetch_and_install(
+            jail=self.jail,
+            packages=pkg_packages,
+            postinstall=postinstall
+        )
+    except Exception as e:
+        yield jailProvisioningEvent.fail(e)
+        raise e
+
+
+def __get_empty_dataset(
+    dataset_name: str,
+    zfs: 'libioc.ZFS.ZFS'
+) -> libzfs.ZFSDataset:
+    try:
+        dataset = zfs.get_dataset(dataset_name)
+    except libzfs.ZFSException:
+        dataset = None
+        pass
+    if dataset is not None:
+        dataset.umount()
+        zfs.delete_dataset_recursive(dataset)
+
+    output: libzfs.ZFSDataset = zfs.get_or_create_dataset(dataset_name)
+    return output

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -168,7 +168,7 @@ def provision(
     self.jail.fstab.save()
 
     if "pkgs" in controlRepoDefinition.keys():
-        pkg_packages = list(controlRepoDefinition["pkgs"])
+        pkg_packages = list(controlRepoDefinition.pkgs)
     else:
         pkg_packages = []
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -215,10 +215,10 @@ def provision(
                 self.jail.logger.verbose(f"Writing r10k config {r10k_cfg}")
                 with open(r10k_cfg, "w") as f:
                     f.write("\n".join([f"---",
-                    ":sources:",
-                    "    puppet:",
-                    f"       basedir: {puppet_env_dir}",
-                    f"       remote: {self.source}\n"]))
+                                       ":sources:",
+                                       "    puppet:",
+                                       f"       basedir: {puppet_env_dir}",
+                                       f"       remote: {self.source}\n"]))
 
                 self.jail.logger.verbose("Deploying r10k config")
                 self.jail.exec([

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -73,12 +73,14 @@ class ControlRepoDefinition(dict):
 
     @property
     def local(self) -> bool:
+        """Return whether this control repo resides locally."""
         if not (self.url.startswith('file://') or self.url.startswith('/')):
             return False
         return True
 
     @property
     def remote(self) -> bool:
+        """Return whether this control repo resides locally."""
         return not self.local
 
     @property
@@ -86,17 +88,17 @@ class ControlRepoDefinition(dict):
         """Return the Puppet Control-Repo URL."""
         return str(self._url)
 
-    @property.setter
-    def url(self) -> str:
+    @url.setter
+    def url(self, value: str) -> None:
         """Set the Puppet Control-Repo URL."""
-        return str(self._url)
+        self._url = value
 
     @property
-    def name(self, value: str) -> str:
+    def name(self) -> str:
         """Return the unique name for this Puppet Control-Repo URL."""
         return self._name
 
-    @property.setter
+    @name.setter
     def name(self, value: str) -> None:
         """Set a unique name for this Puppet Control-Repo URL."""
         self._name = value

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -117,7 +117,10 @@ def provision(
     If the repo is a filesystem path, it will be mounted appropriately.
     If the repo is a URL, it will be setup with `r10k`.
 
-        ioc set provisioning.method=puppet provisioning.source=http://example.com/my/puppet-env myjail
+        ioc set \
+            provisioning.method=puppet \
+            provisioning.source=http://example.com/my/puppet-env \
+            myjail
 
     """
     events = libioc.events

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -128,7 +128,7 @@ class ControlRepoDefinition(dict):
         """
 
         if self.remote:
-            postinstall += """cat > /usr/local/etc/r10k/r10k.yml <EOF
+            postinstall += f"""cat > /usr/local/etc/r10k/r10k.yml <EOF
             ---
             :source:
                 puppet:
@@ -140,7 +140,7 @@ class ControlRepoDefinition(dict):
 
             """
 
-        postinstall += """
+        postinstall += f"""
         puppet apply --debug {basedir}/manifests/site.pp
         """
         return postinstall

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -175,9 +175,10 @@ def provision(
 
     if not (self.source.startswith('file://') or self.source.startswith('/')):
         # clone control repo
-        controlrepo_dataset_name = f"{self.jail.dataset.name}/puppet"
-        controlrepo_dataset = self.zfs.get_or_create_dataset(
-            control_repo_dataset_name, self.jail.zfs)
+        plugin_dataset_name = f"{self.jail.dataset.name}/puppet"
+        plugin_dataset = self.zfs.get_or_create_dataset(
+            plugin_dataset_name
+        )
 
         git.Repo.clone_from(
             pluginDefinition.url,

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2017-2019, Stefan Grönke, Igor Galić
-# Copyright (c) 2014-2018, ioc
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -106,14 +106,20 @@ def provision(
     Provision the jail with Puppet apply using the supplied control-repo.
 
     The repo can either be a filesystem path, or a http[s]/git URL.
-    If the repo is a filesystem path, it will be mounted appropriately.
-    If the repo is a URL, it will be setup with `r10k`.
+    If the repo is a filesystem path, it will be mounted to
+    `/usr/local/etc/puppet/environments`.
+    If the repo is a URL, we will setup a ZFS dataset and mount that to
+    `/usr/local/etc/puppet/environments`, before deploying it with `r10k`.
+
+    Example:
 
         ioc set \
             provisioning.method=puppet \
-            provisioning.source=http://example.com/my/puppet-env \
-            myjail
+            provisioning.source=http://github.com/bsdci/puppet-control-repo \
+            webserver
 
+    This should install a webserver that listens on port 80, and delivers a
+    Hello-World HTML site.
     """
     events = libioc.events
     jailProvisioningEvent = events.JailProvisioning(

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -222,19 +222,3 @@ def provision(
         yield jailProvisioningEvent.fail(e)
         raise e
 
-
-def __get_empty_dataset(
-    dataset_name: str,
-    zfs: 'libioc.ZFS.ZFS'
-) -> libzfs.ZFSDataset:
-    try:
-        dataset = zfs.get_dataset(dataset_name)
-    except libzfs.ZFSException:
-        dataset = None
-        pass
-    if dataset is not None:
-        dataset.umount()
-        zfs.delete_dataset_recursive(dataset)
-
-    output: libzfs.ZFSDataset = zfs.get_or_create_dataset(dataset_name)
-    return output

--- a/libioc/Resource.py
+++ b/libioc/Resource.py
@@ -365,6 +365,28 @@ class Resource(metaclass=abc.ABCMeta):
             "This needs to be implemented by the inheriting class"
         )
 
+    def _require_relative_path(
+        self,
+        filepath: str,
+    ) -> None:
+        if self._is_path_relative(filepath) is False:
+            raise libioc.errors.SecurityViolationConfigJailEscape(
+                file=filepath
+            )
+
+    def _is_path_relative(
+        self,
+        filepath: str
+    ) -> bool:
+
+        real_resource_path = self._resolve_path(self.dataset.mountpoint)
+        real_file_path = self._resolve_path(filepath)
+
+        return real_file_path.startswith(real_resource_path)
+
+    def _resolve_path(self, filepath: str) -> str:
+        return os.path.realpath(os.path.abspath(filepath))
+
 
 class DefaultResource(Resource):
     """The resource storing the default configuration."""

--- a/libioc/Types.py
+++ b/libioc/Types.py
@@ -43,7 +43,7 @@ class Path(str):
             raise TypeError("Path must be a string")
 
         if len(self.blacklist.findall(sequence)) > 0:
-            raise TypeError(f"Illegal path: {sequence}")
+            raise ValueError(f"Illegal path: {sequence}")
 
         self = sequence  # type: ignore
 
@@ -59,7 +59,7 @@ class AbsolutePath(Path):
             raise TypeError("AbsolutePath must be a string or Path")
 
         if str(sequence).startswith("/") is False:
-            raise TypeError(
+            raise ValueError(
                 f"Expected AbsolutePath to begin with /, but got: {sequence}"
             )
 


### PR DESCRIPTION
This patch introduces Puppet (apply) as provisioning method, addressing #625 

So far the design requires a (unique) name, a source (the control-repo) and an optional list of packages to be pre-installed.
By default that List of packages is `puppet6`, and if the source is a git repo, `rubygem-r10k`.

To begin the provisioning, we

- install puppet
- optionall install r10k
- (optionally) clone the control repo
- mount the control-repo
- (optionally, if the repo was cloned) run r10k
- run puppet

we could also consider to run puppet more than once, to guarantee idempotence.