### PR TITLE
Validate BaseConfig data on clone

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -170,7 +170,8 @@ class BaseConfig(dict):
         new_data = libioc.Config.Data.Data(data)
         if current_id is not None:
             new_data["id"] = current_id
-        self.data = new_data
+        for key, value in new_data.items():
+            self.data[key] = value
 
     def read(self, data: dict, skip_on_error: bool=False) -> None:
         """

--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -40,7 +40,6 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
 
     legacy: bool = False
     jail: typing.Optional['libioc.Jail.JailGenerator']
-    data: dict = {}
     ignore_source_config: bool
 
     def __init__(

--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -40,6 +40,7 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
 
     legacy: bool = False
     jail: typing.Optional['libioc.Jail.JailGenerator']
+    data: dict = {}
     ignore_source_config: bool
 
     def __init__(


### PR DESCRIPTION
Before this change, it was possible to initialize a jail with invalid config data.