### PR TITLE
use a virtual basedir to update FreeBSD

### DIFF
--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -317,10 +317,12 @@ class Updater:
             f"Fetching updates for release '{self.release.name}'"
         )
 
-        os.symlink(
-            f"{self.release.root_path}/.zfs/snapshot/p0",
-            self._base_release_symlink_location
-        )
+        symlink_src = self.release.root_path
+        if "p0" in [x.snapshot_name for x in self.release.version_snapshots]:
+            # use p0 snapshot if available
+            symlink_src += "/.zfs/snapshot/p0"
+        os.symlink(symlink_src, self._base_release_symlink_location)
+
         try:
             self._create_download_dir()
             libioc.helpers.exec(

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -411,10 +411,10 @@ class Updater:
         yield executeResourceUpdateEvent.begin()
 
         skipped = False
-        self.resource._require_relative_path(
-            self._base_release_symlink_location
-        )
-        os.symlink("/", self._base_release_symlink_location)
+
+        lnk = f"{self.resource.root_path}{self._base_release_symlink_location}"
+        self.resource._require_relative_path(lnk)
+        os.symlink("/", lnk)
         try:
             self._create_jail_update_dir()
             for event in libioc.Jail.JailGenerator.fork_exec(
@@ -454,7 +454,7 @@ class Updater:
                     force=True,
                     event_scope=executeResourceUpdateEvent.scope
                 )
-            os.unlink(self._base_release_symlink_location)
+            os.unlink(lnk)
 
         if skipped is True:
             yield executeResourceUpdateEvent.skip("already up to date")


### PR DESCRIPTION
fixes #624

There was an issue on FreeBSD 12 where releases, although being outdated, did not fetch updates. The freebsd-update.sh argument `-b` changes the `BASEDIR`, which internally influences the `BDHASH` that is re-used during update installation.

```sh
# Construct a unique name from ${BASEDIR}
BDHASH=`echo ${BASEDIR} | sha256 -q`
```

see [/usr.sbin/freebsd-update/freebsd-update.sh#L723-L724](https://github.com/freebsd/freebsd/blob/d997b9accb5cbd8d0dc9c99179e70d52bfabaf50/usr.sbin/freebsd-update/freebsd-update.sh#L723-L724)

By creating a symlink on the host to `<Release.dataset_name>/root/tmp/ioc-release-<Release.full_name>-p0` and on the jail side to `/` the same `BASEDIR` can be used while `freebsd-update.sh` on the host side still fetches updates against `p0` of a Release.