### PR TITLE
remove singleton data instance from JailConfig

### DIFF
--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -40,7 +40,7 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
 
     legacy: bool = False
     jail: typing.Optional['libioc.Jail.JailGenerator']
-    data: dict = {}
+    data: dict
     ignore_source_config: bool
 
     def __init__(


### PR DESCRIPTION
Fixes an issue where all jails inherited the config from the first loaded jail.