### PR TITLE
Unhide shared ZFS zvol devices

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -520,10 +520,7 @@ class JailGenerator(JailResource):
                 exec_start.append("service ipfw onestop")
 
         if self.config["jail_zfs"] is True:
-            share_storage = libioc.ZFSShareStorage.QueuingZFSShareStorage(
-                jail=self,
-                logger=self.logger
-            )
+            share_storage = self._zfs_share_storage
             share_storage.mount_zfs_shares()
             exec_start += share_storage.read_commands("jail")
             exec_created += share_storage.read_commands()
@@ -614,6 +611,15 @@ class JailGenerator(JailResource):
             raise e
 
         yield jailLaunchEvent.end(stdout=stdout)
+
+    @property
+    def _zfs_share_storage(
+        self
+    ) -> libioc.ZFSShareStorage.QueuingZFSShareStorage:
+        return libioc.ZFSShareStorage.QueuingZFSShareStorage(
+            jail=self,
+            logger=self.logger
+        )
 
     def _start_dependant_jails(
         self,

--- a/libioc/ZFSShareStorage.py
+++ b/libioc/ZFSShareStorage.py
@@ -25,6 +25,7 @@
 """iocage ZFS share storage backend."""
 import typing
 import libzfs
+import shlex
 
 import libioc.errors
 import libioc.helpers
@@ -58,23 +59,23 @@ class ZFSShareStorage:
                 "/sbin/zfs",
                 "set",
                 "jailed=off",
-                dataset.name
+                shlex.quote(dataset.name)
             ])
             self._exec([
                 "/sbin/zfs",
                 "umount",
-                dataset.name
+                shlex.quote(dataset.name)
             ])
             self._exec([
                 "/sbin/zfs",
                 "mount",
-                dataset.name
+                shlex.quote(dataset.name)
             ])
             self._exec([
                 "/sbin/zfs",
                 "set",
                 "jailed=on",
-                dataset.name
+                shlex.quote(dataset.name)
             ])
 
     def get_zfs_datasets(
@@ -125,7 +126,7 @@ class ZFSShareStorage:
 
             # ToDo: bake jail feature into py-libzfs
             self._exec(
-                self._zfs_jail_command + [dataset.name],
+                self._zfs_jail_command + [shlex.quote(dataset.name)],
                 logger=self.logger
             )
 

--- a/libioc/ZFSShareStorage.py
+++ b/libioc/ZFSShareStorage.py
@@ -87,18 +87,18 @@ class ZFSShareStorage:
         datasets = set()
         for name in dataset_names:
 
-            try:
-                zpool = self._get_pool_from_dataset_name(name)
-            except libioc.errors.ZFSPoolUnavailable:
-                # legacy support (datasets not prefixed with pool/)
-                zpool = self.jail.pool
-                name = f"{self.jail.pool_name}/{name}"
+            if auto_create is True:
+                try:
+                    zpool = self._get_pool_from_dataset_name(name)
+                except libioc.errors.ZFSPoolUnavailable:
+                    # legacy support (datasets not prefixed with pool/)
+                    zpool = self.jail.pool
+                    name = f"{self.jail.pool_name}/{name}"
 
-            try:
-                if auto_create is True:
+                try:
                     zpool.create(name, {}, create_ancestors=True)
-            except libzfs.ZFSException:
-                pass
+                except libzfs.ZFSException:
+                    pass
 
             try:
                 dataset = self.zfs.get_dataset(name)


### PR DESCRIPTION
When ZFS datasets are shared with a jail, their according zvol dev volumes should also appear in the jail.

For instance this is required when following the [article on VMs in jails](https://github.com/lattera/articles/blob/master/freebsd/2018-10-27_jailed_bhyve/article.md) by @lattera.

- Unhides the shared ZFS volumes and their child datasets
- Quotes dataset names in shell commands with shlex