### PR TITLE
Obtain jail parameters from sysctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ JAIL_NET?=16
 MYPYPATH = $(shell pwd)/.travis/mypy-stubs
 
 deps:
-	if [ "`uname`" = "FreeBSD" ]; then pkg install -q -y libucl py36-cython rsync python36 py36-libzfs py36-sysctl; fi
+	if [ "`uname`" = "FreeBSD" ]; then pkg install -q -y libucl py36-cython rsync python36 py36-libzfs; fi
 	python3.6 -m ensurepip
 	python3.6 -m pip install -Ur requirements.txt
 install: deps

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -32,6 +32,7 @@ import libioc.Config.Jail.Properties
 import libioc.errors
 import libioc.helpers
 import libioc.helpers_object
+import libioc.JailParams
 
 # mypy
 import libioc.Logger
@@ -815,6 +816,8 @@ class BaseConfig(dict):
 
     def _is_known_property(self, key: str) -> bool:
         """Return True when the key is a known config property."""
+        if self._is_known_jail_param(key):
+            return True
         if key in libioc.Config.Jail.Defaults.DEFAULTS.keys():
             return True  # key is default
         if f"_set_{key}" in dict.__dir__(self):
@@ -826,6 +829,9 @@ class BaseConfig(dict):
         if self._is_user_property(key) is True:
             return True  # user.* property
         return False
+
+    def _is_known_jail_param(self, key: str) -> bool:
+        return key in libioc.JailParams.HostJailParams()
 
     @property
     def _sorted_user_properties(self) -> typing.List[str]:

--- a/libioc/Config/Jail/Defaults.py
+++ b/libioc/Config/Jail/Defaults.py
@@ -94,7 +94,7 @@ DEFAULTS = libioc.Config.Data.Data({
     "mount_procfs": "0",
     "mount_devfs": "1",
     "mount_fdescfs": "0",
-    "securelevel": "2",
+    "securelevel": 2,
     "tags": [],
     "template": False,
     "jail_zfs": False,

--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -63,9 +63,10 @@ class Firewall:
             return
 
         try:
-            for key in self._required_sysctl_properties:
-                current = freebsd_sysctl.Sysctl(key).value
+            current = "not found"
+            for key in requirements:
                 expected = requirements[key]
+                current = freebsd_sysctl.Sysctl(key).value
                 if current == expected:
                     raise ValueError(
                         f"Invalid Sysctl {key}: "

--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -73,6 +73,7 @@ class Firewall:
                     )
             return
         except Exception:
+            # an IocageException is raised in the next step at the right level
             pass
 
         hint = f"sysctl {key} is expected to be {expected}, but was {current}"

--- a/libioc/Host.py
+++ b/libioc/Host.py
@@ -27,7 +27,7 @@ import typing
 import os
 import platform
 import re
-import sysctl
+import freebsd_sysctl
 
 import libzfs
 
@@ -187,8 +187,11 @@ class HostGenerator:
     @property
     def ipfw_enabled(self) -> bool:
         """Return True if ipfw is enabled on the host system."""
-        _sysctl = sysctl.filter("net.inet.ip.fw.enable")
-        return ((len(_sysctl) == 1) and (_sysctl[0].value == 1))
+        try:
+            firewall_enabled = freebsd_sysctl.Sysctl("net.inet.ip.fw.enable")
+            return (firewall_enabled.value == 1) is True
+        except Exception:
+            return False
 
 
 class Host(HostGenerator):

--- a/libioc/Host.py
+++ b/libioc/Host.py
@@ -54,7 +54,7 @@ class HostGenerator:
 
     _devfs: libioc.DevfsRules.DevfsRules
     _defaults: libioc.Resource.DefaultResource
-    __user_provided_defaults: typing.Dict[str, typing.Any]
+    __user_provided_defaults: typing.Optional[libioc.Resource.DefaultResource]
     __hostid: str
     releases_dataset: libzfs.ZFSDataset
     datasets: libioc.Datasets.Datasets

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1661,6 +1661,7 @@ class JailGenerator(JailResource):
     @property
     def _launch_args(self) -> typing.List[str]:
         config = self.config
+        vnet = (config["vnet"] is True)
         value: str
         jail_param_args: typing.List[str] = []
         for sysctl_name, sysctl in libioc.JailParams.JailParams().items():
@@ -1677,11 +1678,13 @@ class JailGenerator(JailResource):
             elif sysctl_name == "security.jail.param.allow.mount.zfs":
                 value = str(self._allow_mount_zfs)
             elif sysctl_name == "security.jail.param.vnet":
-                if config["vnet"] is False:
+                if vnet is False:
                     # vnet is only used when explicitly enabled
                     # (friendly to Kernels without VIMAGE support)
                     continue
                 value = "vnet"
+            elif vnet and sysctl_name.startswith("security.jail.param.ip"):
+                continue
             else:
                 config_property_name = sysctl.iocage_name
                 if self.config._is_known_property(config_property_name):

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1983,16 +1983,16 @@ class JailGenerator(JailResource):
         return [f"/usr/bin/rctl -r jail:{self.identifier} 2>/dev/null || true"]
 
     @property
-    def _allow_mount(self) -> str:
-        if self._allow_mount_zfs == "1":
-            return "1"
-        return self._get_value("allow_mount")
+    def _allow_mount(self) -> int:
+        if self._allow_mount_zfs == 1:
+            return 1
+        return int(self._get_value("allow_mount"))
 
     @property
-    def _allow_mount_zfs(self) -> str:
+    def _allow_mount_zfs(self) -> int:
         if self.config["jail_zfs"] is True:
-            return "1"
-        return self._get_value("allow_mount_zfs")
+            return 1
+        return int(self._get_value("allow_mount_zfs"))
 
     def _configure_routes_commands(self) -> typing.List[str]:
 

--- a/libioc/JailParams.py
+++ b/libioc/JailParams.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Sysctl jail params signeton."""
+import typing
+import freebsd_sysctl
+import collections.abc
+
+class HostJailParams(collections.abc.MutableMapping):
+    __params: typing.Dict[str, freebsd_sysctl.Sysctl]
+
+    def __iter__(self) -> typing.Iterator[str]:
+        """Iterate over the jail param names."""
+        yield self.memoized_params.__iter__()
+    
+    def __len__(self) -> int:
+        """Return the number of available jail params."""
+        return self.memoized_params.__len__()
+
+    def items(self) -> typing.ItemsView[str, typing.Any]:
+        """Iterate over the keys and values."""
+        return typing.cast(
+            typing.ItemsView[str, typing.Any],
+            self.memoized_params.items()
+        )
+
+    def keys(self) -> typing.KeysView[str]:
+        """Return a list of all jail param names."""
+        return collections.abc.KeysView(*list(self.__iter__()))  # noqa: T484
+
+    def __getitem__(self, key: str) -> typing.Any:
+        """Set of jail params sysrc is not implemented."""
+        return self.memoized_params.__getitem__(key)
+
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        """Set of jail params sysrc is not supportes."""
+        raise NotImplementedError("jail param sysctl cannot be modified")
+
+    def __delitem__(self, key: str, value: typing.Any) -> None:
+        """Delete of jail param sysrc not supported."""
+        raise NotImplementedError("jail param sysctl cannot be deleted")
+
+    @property
+    def memoized_params(self) -> typing.Dict[str, freebsd_sysctl.Sysctl]:
+        try:
+            return self.__params
+        except AttributeError:
+            pass
+        self.__update_sysrc_jail_params()
+        return self.__params
+
+    def __update_sysrc_jail_params(self) -> None:
+        prefix = "security.jail.param"
+        jail_params = filter(
+            lambda x: x.name.endswith(".") is False,  # filter NODE
+            freebsd_sysctl.Sysctl(prefix).children
+        )
+        HostJailParams.__params = dict(
+            [(x.name[len(prefix) + 1:], x,) for x in jail_params]
+        )

--- a/libioc/JailParams.py
+++ b/libioc/JailParams.py
@@ -49,7 +49,8 @@ class JailParam(freebsd_sysctl.Sysctl):
         """Set the user defined value of this jail parameter."""
         if self.ctl_type == freebsd_sysctl.types.NODE:
             raise TypeError("sysctl NODE has no value")
-        elif self.ctl_type in [
+
+        if self.ctl_type in [
             freebsd_sysctl.types.STRING,
             freebsd_sysctl.types.OPAQUE,
         ]:

--- a/libioc/JailParams.py
+++ b/libioc/JailParams.py
@@ -114,7 +114,7 @@ class JailParams(collections.abc.MutableMapping):
     """Collection of jail parameters."""
 
     __base_class = JailParam
-    __sysrc_params: typing.Dict[str, freebsd_sysctl.Sysctl]
+    __sysctl_params: typing.Dict[str, freebsd_sysctl.Sysctl]
 
     def __iter__(self) -> typing.Iterator[str]:
         """Iterate over the jail param names."""
@@ -133,28 +133,28 @@ class JailParams(collections.abc.MutableMapping):
         return collections.abc.KeysView(list(self.__iter__()))  # noqa: T484
 
     def __getitem__(self, key: str) -> typing.Any:
-        """Set of jail params sysrc is not implemented."""
+        """Set of jail params sysctl is not implemented."""
         return self.memoized_params.__getitem__(key)
 
     def __setitem__(self, key: str, value: typing.Any) -> None:
-        """Set of jail params sysrc is not supportes."""
+        """Set of jail params sysctl is not supportes."""
         self.memoized_params.__setitem__(key, value)
 
     def __delitem__(self, key: str) -> None:
-        """Delete of jail param sysrc not supported."""
+        """Delete of jail param sysctl not supported."""
         self.memoized_params.__delitem__(key)
 
     @property
     def memoized_params(self) -> typing.Dict[str, freebsd_sysctl.Sysctl]:
         """Return the memorized params initialized on first access."""
         try:
-            return self.__sysrc_params
+            return self.__sysctl_params
         except AttributeError:
             pass
-        self.__update_sysrc_jail_params()
-        return self.__sysrc_params
+        self.__update_sysctl_jail_params()
+        return self.__sysctl_params
 
-    def __update_sysrc_jail_params(self) -> None:
+    def __update_sysctl_jail_params(self) -> None:
         prefix = "security.jail.param"
         jail_params = filter(
             lambda x: not any((
@@ -163,19 +163,19 @@ class JailParams(collections.abc.MutableMapping):
             )),
             self.__base_class(prefix).children
         )
-        # permanently store the queried sysrc in the singleton class
-        JailParams.__sysrc_params = dict([(x.name, x,) for x in jail_params])
+        # permanently store the queried sysctl in the singleton class
+        JailParams.__sysctl_params = dict([(x.name, x,) for x in jail_params])
 
 
 class HostJailParams(JailParams):
-    """Read-only host jail parameters obtained from sysrc."""
+    """Read-only host jail parameters obtained from sysctl."""
 
     __base_class = freebsd_sysctl.Sysctl
 
     def __setitem__(self, key: str, value: typing.Any) -> None:
-        """Set of jail params sysrc is not supportes."""
+        """Set of jail params sysctl is not supportes."""
         raise NotImplementedError("jail param sysctl cannot be modified")
 
     def __delitem__(self, key: str) -> None:
-        """Delete of jail param sysrc not supported."""
+        """Delete of jail param sysctl not supported."""
         raise NotImplementedError("jail param sysctl cannot be deleted")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ucl==0.8.0
 gitpython
-freebsd_sysctl
+freebsd_sysctl==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ucl==0.8.0
 gitpython
+freebsd_sysctl


### PR DESCRIPTION
All jail parameters supported on a host can be obtained from sysctl. To do so this branch calls a native interface to get the param names, their type and maximum length.

~~The first draft obtains the data with py-sysctl, but a final version should use libc instead.~~

The prior py-sysctl Cython dependency has been replaced with a native Python 3 [freebsd_sysctl](https://github.com/gronke/py-freebsd_sysctl) module.