### PR TITLE
Create p0 snapshot from plain Release

### DIFF
--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -735,6 +735,8 @@ class ReleaseGenerator(ReleaseResource):
         else:
             yield releaseConfigurationEvent.skip()
 
+        self.snapshot("p0")
+
         if fetch_updates is True:
             try:
                 for event in self.updater.fetch(event_scope=_scope):


### PR DESCRIPTION
All release updates are fetched against the `p0` snapshot. Right after a release was extracted and configured, the snapshot can be taken.