### PR TITLE
Fix installing pkg for older releases

### DIFF
--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -113,9 +113,13 @@ class Pkg:
             ],
             logger=self.logger,
             env=dict(
+                ABI=self.__get_abi_string(release_major_version),
                 SIGNATURE_TYPE="fingerprints"
             )
         )
+
+    def __get_abi_string(self, release_major_version: int) -> str:
+        return f"FreeBSD:{release_major_version}:{self.host.processor}"
 
     def _mirror_packages(
         self,
@@ -132,6 +136,7 @@ class Pkg:
             ] + packages,
             logger=self.logger,
             env=dict(
+                ABI=self.__get_abi_string(release_major_version),
                 SIGNATURE_TYPE="fingerprints"
             )
         )
@@ -149,6 +154,7 @@ class Pkg:
                 cache_ds.mountpoint
             ],
             env=dict(
+                ABI=self.__get_abi_string(release_major_version),
                 SIGNATURE_TYPE="fingerprints",
                 FINGERPRINTS="/usr/share/keys/pkg"
             ),
@@ -361,6 +367,7 @@ class Pkg:
         self._update_pkg_conf(
             filename=f"{conf_ds.mountpoint}/pkg.conf",
             data=dict(
+                ABI=self.__get_abi_string(release_major_version),
                 PKG_DBDIR=db_ds.mountpoint,
                 PKG_CACHEDIR=cache_ds.mountpoint,
                 REPOS_DIR=[str(repos_ds.mountpoint)],

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -142,7 +142,9 @@ class Pkg:
         )
 
         if (stderr is not None) and (len(stderr) > 0):
-            raise libioc.errors.PkgNotFound(stderr, logger=self.logger)
+            lines = stderr.split("\n")
+            if not all((line.startswith("pkg: Warning: ") for line in lines)):
+                raise libioc.errors.PkgNotFound(stderr, logger=self.logger)
 
     def _build_mirror_index(self, release_major_version: int) -> None:
         pkg_ds = self._get_release_pkg_dataset(release_major_version)

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -70,7 +70,7 @@ class Pkg:
         """Fetch a bunch of packages to the local mirror."""
         _packages = self._normalize_packages(packages)
         _packages.append("pkg")
-        release_major_version = math.floor(release.version_number)
+        release_major_version = int(math.floor(release.version_number))
         pkg_ds = self._get_release_pkg_dataset(release_major_version)
 
         packageFetchEvent = libioc.events.PackageFetch(


### PR DESCRIPTION
When installing pkg for a jail with release older than the host, pkg complained about the ABI mismatch. The `ABI=FreeBSD:<RELEASE_MAJOR_VERSION>:<PROCESSOR_ARCH>` env variable is set on all host pkg commands, to match the releases ABI.