### PR TITLE
check hostid on Jail.start when hostid_strict_check is enabled

### DIFF
--- a/libioc/Config/Jail/Defaults.py
+++ b/libioc/Config/Jail/Defaults.py
@@ -56,6 +56,8 @@ DEFAULTS = libioc.Config.Data.Data({
     "host_hostuuid": None,
     "host_hostname": None,
     "host_domainname": None,
+    "hostid": None,
+    "hostid_strict_check": False,
     "devfs_ruleset": 4,
     "enforce_statfs": 2,
     "children_max": 0,

--- a/libioc/Host.py
+++ b/libioc/Host.py
@@ -55,6 +55,7 @@ class HostGenerator:
     _devfs: libioc.DevfsRules.DevfsRules
     _defaults: libioc.Resource.DefaultResource
     _defaults_initialized = False
+    __hostid: str
     releases_dataset: libzfs.ZFSDataset
     datasets: libioc.Datasets.Datasets
     distribution: _distribution_types
@@ -113,6 +114,19 @@ class HostGenerator:
                 logger=self.logger,
                 zfs=self.zfs
             )
+
+    @property
+    def id(self) -> str:
+        """Return the hostid and memoize on first lookup."""
+        try:
+            return self.__hostid
+        except AttributeError:
+            pass
+
+        with open("/etc/hostid", "r") as f:
+            self.__hostid = f.read().strip()
+
+        return self.__hostid
 
     @property
     def defaults(self) -> 'libioc.Resource.DefaultResource':

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -461,6 +461,23 @@ class ResourceLimitUnknown(IocException, KeyError):
         IocException.__init__(self, message=msg, logger=logger)
 
 
+class JailHostIdMismatch(JailException):
+    """Raised when attempting to start a jail with mismatching hostid."""
+
+    def __init__(
+        self,
+        host_hostid: str,
+        jail: 'libioc.Jail.JailGenerator',
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+        jail_hostid = jail.config["hostid"]
+        msg = (
+            f"The jail hostid '{jail_hostid}' "
+            f"does not match the hosts hostid '{host_hostid}'"
+        )
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
+
+
 class JailConfigNotFound(IocException):
     """Raised when a jail is not configured."""
 


### PR DESCRIPTION
closes #634 

When the JailConfig property `hostid_strict_check` is enabled, the jails `hostid` is matched against `/etc/hostid` on the host. libioc refuses to start Jails with mismatch in the values with a `JailHostIdMismatch` exception.