### PR TITLE
existing data keys do not cause UnknownJailProperty when read

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -613,6 +613,13 @@ class BaseConfig(dict):
         # plain data attribute
         return libioc.helpers.parse_user_input(self.data[key])
 
+    @property
+    def unknown_config_parameters(self) -> typing.Iterator[str]:
+        """Yield unknown config parameters already stored in the config."""
+        for key in self.data.keys():
+            if self._is_known_property(key) is False:
+                yield key
+
     def __delitem__(self, key: str) -> None:
         """Delete a setting from the configuration."""
         self.data.__delitem__(key)

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -597,7 +597,8 @@ class BaseConfig(dict):
 
         A KeyError is raised when no criteria applies.
         """
-        self._require_known_config_property(key)
+        if key not in self.data.keys():
+            self._require_known_config_property(key)
 
         # special property
         if self.special_properties.is_special_property(key) is True:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -589,6 +589,14 @@ class JailGenerator(JailResource):
             self.storage_backend.apply(self.storage, self.release)
 
         if quick is False:
+            unknown_config_parameters = list(
+                self.config.unknown_config_parameters
+            )
+            if len(unknown_config_parameters) > 0:
+                _unused_parameters = str(", ".join(unknown_config_parameters))
+                self.logger.warn(
+                    f"Unused JailConfig parameters: {_unused_parameters}"
+                )
             self._save_autoconfig()
 
         try:


### PR DESCRIPTION
Fixes an issue interfacing with legacy jails that have unsupported jail properties. When reading such values from jails that have loaded them from an existing configuration storage (json, zfs, ucl), no error is raised. This allows to unset such values and starting jails with existing, but unsupported JailConfig parameters.