### PR TITLE
install py36-sqlite during make install-dev on FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ script:
   - make check
 notifications:
   email: false
+addons:
+  apt:
+    packages:
+      - sqlite3

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ install: deps
 	python3.6 -m pip install -U .
 install-dev: deps
 	if [[ "`uname`" = "FreeBSD" ]]; then pkg install -y gmake py36-sqlite3; fi
-	apt install -y sqlite3 python3 2>/dev/null || true
 	python3.6 -m pip install -Ur requirements-dev.txt
 	python3.6 -m pip install -e .
 install-travis:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install: deps
 	python3.6 -m pip install -U .
 install-dev: deps
 	if [[ "`uname`" = "FreeBSD" ]]; then pkg install -y gmake py36-sqlite3; fi
+	apt install -y sqlite3 python3 2>/dev/null || true
 	python3.6 -m pip install -Ur requirements-dev.txt
 	python3.6 -m pip install -e .
 install-travis:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps:
 install: deps
 	python3.6 -m pip install -U .
 install-dev: deps
-	if [ "`uname`" = "FreeBSD" ]; then pkg install -y gmake; fi
+	if [[ "`uname`" = "FreeBSD" ]]; then pkg install -y gmake py36-sqlite3; fi
 	python3.6 -m pip install -Ur requirements-dev.txt
 	python3.6 -m pip install -e .
 install-travis:


### PR DESCRIPTION
Addresses a dependency issue of MyPy, that began to depend on sqlite3.

see https://github.com/python/mypy/issues/6207