### PR TITLE
disable creation of ZFS basejail assets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ ioc rename othersource/myjail myjail2
 
 When `othersource` is the only datasource with a jail named `myjail` the above operation would have worked without explicitly stating the dataset name.
 
+### Legacy Support
+
+With upcoming releases existing and future legacy / compatibility features will be disabled by default. Setting the sysrc ioc_legacy_support="YES" these compatibility features:
+
+- ZFS Basejail Support (iocage_legacy)
+
+On initialization libioc detects the hosts sysrc setting `ioc_legacy_support` that can be enabled to unlock features liste above.
+
+```sh
+sysrc ioc_legacy_support="YES"
+```
+
 ## Usage
 
 ### Library

--- a/libioc/Config/Host/__init__.py
+++ b/libioc/Config/Host/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Host Configuration."""
+import typing
+
+import libioc.Config.Jail.File.RCConf
+
+
+class RCConf(libioc.Config.Jail.File.RCConf):
+	"""Host RCConf file /etc/rc.conf."""
+
+	def save(self) -> bool:
+		"""Prevent saving the host /etc/rc.conf file."""
+		raise NotImplementedError("Host rc.conf cannot be saved.")
+
+
+rc_conf = RCConf()

--- a/libioc/Config/Host/__init__.py
+++ b/libioc/Config/Host/__init__.py
@@ -27,7 +27,7 @@ import typing
 import libioc.Config.Jail.File.RCConf
 
 
-class RCConf(libioc.Config.Jail.File.RCConf):
+class RCConf(libioc.Config.Jail.File.RCConf.RCConf):
 	"""Host RCConf file /etc/rc.conf."""
 
 	def save(self) -> bool:

--- a/libioc/Config/Jail/File/__init__.py
+++ b/libioc/Config/Jail/File/__init__.py
@@ -75,7 +75,6 @@ class ConfigFile(dict):
 
     def _read_file(
         self,
-        silent: bool=False,
         delete: bool=False,
         merge: bool=False
     ) -> None:
@@ -83,9 +82,6 @@ class ConfigFile(dict):
         Read the config file.
 
         Args:
-
-            silent:
-                Do not use the logger
 
             delete:
                 Delete entries that do not exist in the file
@@ -95,7 +91,7 @@ class ConfigFile(dict):
         """
         try:
             if (self.path is not None) and os.path.isfile(self.path):
-                data = self._read(silent=silent)
+                data = self._read()
             else:
                 data = {}
         except (FileNotFoundError, ValueError):
@@ -118,8 +114,7 @@ class ConfigFile(dict):
                 self[key] = data[key]
                 self._file_content_changed = True
 
-        if silent is False:
-            self.logger.verbose(f"Updated {self._file} data from {self.path}")
+        self.logger.verbose(f"Updated {self._file} data from {self.path}")
 
         if delete is False and len(delete_keys) > 0:
             # There are properties that are not in the file
@@ -128,7 +123,7 @@ class ConfigFile(dict):
             # Current data matches with file contents
             self._file_content_changed = False
 
-    def _read(self, silent: bool=False) -> dict:
+    def _read(self) -> dict:
         import ucl
         data = dict(ucl.load(open(self.path).read()))
         self.logger.spam(f"{self._file} was read from {self.path}")

--- a/libioc/Datasets.py
+++ b/libioc/Datasets.py
@@ -30,6 +30,7 @@ import libzfs
 import libioc.errors
 import libioc.helpers
 import libioc.helpers_object
+import libioc.Config.Host
 
 # MyPy
 import libioc.Types
@@ -334,10 +335,7 @@ class Datasets(dict):
     def _read_root_datasets_from_rc_conf(self) -> typing.Dict[str, str]:
         prefix = "ioc_dataset_"
 
-        import libioc.Config.Jail.File.RCConf
-        rc_conf = libioc.Config.Jail.File.RCConf.RCConf(
-            logger=self.logger
-        )
+        rc_conf = libioc.Config.Host.rc_conf
         rc_conf_keys = list(filter(lambda x: x.startswith(prefix), rc_conf))
 
         output: typing.Dict[str, str] = {}

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -650,7 +650,8 @@ class ReleaseGenerator(ReleaseResource):
         self,
         update: typing.Optional[bool]=None,
         fetch_updates: typing.Optional[bool]=None,
-        event_scope: typing.Optional['libioc.events.Scope']=None
+        event_scope: typing.Optional['libioc.events.Scope']=None,
+        update_base: bool=False
     ) -> typing.Generator['libioc.events.IocEvent', None, None]:
         """Fetch the release from the remote."""
         release_changed = False
@@ -757,8 +758,14 @@ class ReleaseGenerator(ReleaseResource):
 
         if release_changed is True:
             yield releaseCopyBaseEvent.begin()
-            self.update_base_release()
-            yield releaseCopyBaseEvent.end()
+
+            if update_base is True:
+                self.update_base_release()
+                yield releaseCopyBaseEvent.end()
+            else:
+                yield releaseCopyBaseEvent.skip(
+                    message="legacy basejal support disabled"
+                )
         else:
             yield releaseCopyBaseEvent.skip(message="release unchanged")
 

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -700,7 +700,9 @@ class FreeBSD(Updater):
     def _pre_update(self) -> None:
         """Execute before executing the update command."""
         lnk = f"{self.resource.root_path}{self._base_release_symlink_location}"
-        self.resource._require_relative_path(lnk)
+        self.resource._require_relative_path(f"{lnk}/..")
+        if os.path.islink(lnk) is True:
+            os.unlink(lnk)
         os.symlink("/", lnk)
 
     def _post_update(self) -> None:

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -444,7 +444,6 @@ class Updater:
             yield executeResourceUpdateEvent.fail(err)
             raise e
         finally:
-            jail.state.query()
             if jail.running:
                 self.logger.debug(
                     "The update jail is still running. "


### PR DESCRIPTION
fixes #542

iocage_legacy basejails are created by cloning a dataset for each basejail_dir from `/iocage/base/<RELEASE>/<BASEJAIL_DIR>` into the jail. Due to performance reasons and the additionally created ZFS datasets this method was replaced by NullFS mounts in python-iocage.

Compatibility with iocage_legacy requires the ZFS release bases to be updated on each release modification, which doubles the required space and also slows down release operations.

Users who require this feature may enable it in `/etc/rc.conf`:

```sh
sysrc ioc_legacy_support="YES"
```