### PR TITLE
invert (fix) sysctl firewall check for secure vnet

### DIFF
--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -67,7 +67,7 @@ class Firewall:
             for key in requirements:
                 expected = requirements[key]
                 current = freebsd_sysctl.Sysctl(key).value
-                if current == expected:
+                if int(current) != int(expected):
                     raise ValueError(
                         f"Invalid Sysctl {key}: "
                         f"{current} found, but expected: {expected}"


### PR DESCRIPTION
The ipfw sysctl lookups of the Secure VNET Firewall were inverted, so that it was not possible to start a jail using a Secure VNET configuration (e.g. `interfaces="vnet0::bridge0`), although the host was configured correctly and running IPFW.