### PR TITLE
Repair shared ZFS datasets

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -442,12 +442,14 @@ class BaseConfig(dict):
         self,
         value: typing.Optional[typing.Union[bool, str]],
     ) -> None:
-        parsed_value = libioc.helpers.parse_user_input(value)
-        if parsed_value is None:
+        try:
+            libioc.helpers.parse_none(value)
             del self.data["jail_zfs"]
             return
+        except TypeError:
+            pass
         self.data["jail_zfs"] = libioc.helpers.to_string(
-            parsed_value,
+            libioc.helpers.parse_bool(value),
             true="on",
             false="off"
         )

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -414,7 +414,7 @@ class JailGenerator(JailResource):
                 reduces to the `prestart`, `command` and `poststop` hooks with
                 the singe_command being executed in a /bin/sh context.
 
-            event_scope (libioc.lib.events.Scope): (default=None)
+            event_scope (libioc.events.Scope): (default=None)
 
                 Provide an existing libiocage event scope or automatically
                 create a new one instead.
@@ -755,7 +755,7 @@ class JailGenerator(JailResource):
 
                 Execute commands in an interactive shell.
 
-            event_scope (libioc.lib.events.Scope): (default=None)
+            event_scope (libioc.events.Scope): (default=None)
 
                 Provide an existing libiocage event scope or automatically
                 create a new one instead.
@@ -918,7 +918,7 @@ class JailGenerator(JailResource):
             force (bool): (default=False)
                 Ignores failures and enforces teardown if True.
 
-            event_scope (libioc.lib.events.Scope): (default=None)
+            event_scope (libioc.events.Scope): (default=None)
                 Provide an existing libiocage event scope or automatically
                 create a new one instead.
 
@@ -1119,7 +1119,7 @@ class JailGenerator(JailResource):
                 )
                 for event in stop_events:
                     yield event
-            except libioc.lib.errors.JailDestructionFailed:
+            except libioc.errors.JailDestructionFailed:
                 pass
 
         zfsDatasetDestroyEvent = libioc.events.ZFSDatasetDestroy(
@@ -2344,7 +2344,7 @@ class Jail(JailGenerator):
 
                 Execute commands in an interactive shell.
 
-            event_scope (libioc.lib.events.Scope): (default=None)
+            event_scope (libioc.events.Scope): (default=None)
 
                 Provide an existing libiocage event scope or automatically
                 create a new one instead.

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -254,9 +254,9 @@ def parse_bool(data: typing.Optional[typing.Union[str, bool]]) -> bool:
         return data
     if isinstance(data, str):
         val = data.lower()
-        if val in ["yes", "true", "on"]:
+        if val in ["yes", "true", "on", "1", 1]:
             return True
-        elif val in ["no", "false", "off"]:
+        elif val in ["no", "false", "off", "0", 0]:
             return False
 
     raise TypeError("Value is not a boolean")

--- a/tests/test_SharedZFS.py
+++ b/tests/test_SharedZFS.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for Jail."""
+import json
+import os
+import random
+
+import pytest
+import libzfs
+
+import libioc.Jail
+
+
+def read_jail_config_json(config_file: str) -> dict:
+    """Read the jail JSON config file."""
+    with open(config_file, "r") as conf:
+        return dict(json.load(conf))
+
+
+@pytest.fixture(scope="function")
+def shared_zfs_dataset(
+    root_dataset: libzfs.ZFSDataset,
+    zfs: libzfs.ZFS
+) -> libzfs.ZFSDataset:
+    name = f"{root_dataset.name}/shared-" + str(random.randint(1, 32768))
+    root_dataset.pool.create(name, {})
+    dataset = zfs.get_dataset(name)
+    dataset.properties["jailed"] = libzfs.ZFSUserProperty("on")
+    yield dataset
+    dataset.delete()
+
+
+class TestSharedZFSDataset(object):
+    """Run Jail unit tests."""
+
+    def test_mount_shared_zfs_dataset_on_start(
+        self,
+        shared_zfs_dataset: libzfs.ZFSDataset,
+        new_jail: 'libioc.Jail.Jail',
+        local_release: 'libioc.Release.ReleaseGenerator',
+    ) -> None:
+        """Test if jails can be created."""
+        new_jail.config["jail_zfs"] = True
+        new_jail.config["jail_zfs_dataset"] = shared_zfs_dataset.name
+        new_jail.create(local_release)
+
+        new_jail.start()
+
+        stdout, _, code = new_jail.exec(["/sbin/zfs", "list"])
+        assert shared_zfs_dataset.name in stdout


### PR DESCRIPTION
With the transition to sysctl, the `jail_zfs` config property was handled incorrectly.

- Handle `jail_zfs` as boolean value
- Correct namespace libioc.lib to libioc in Jail module
- Test the ability to share ZFS datasets with a jail