### PR TITLE
update py-jail and py-freebsd_sysctl to fix utf-8 issues installing them

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ucl==0.8.0
 gitpython
-freebsd_sysctl==0.0.4
-jail==0.0.3
+freebsd_sysctl==0.0.5
+jail==0.0.4


### PR DESCRIPTION
Update Python dependencies [jail](https://github.com/gronke/py-jail) and [freebsd_sysctl](https://github.com/gronke/py-freebsd_sysctl), so that installation is supported without UTF-8 locale on FreeBSD.