### PR TITLE
Stop jails with libjail

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -471,6 +471,9 @@ class JailGenerator(JailResource):
         ]
         exec_poststart: typing.List[str] = []
 
+        if self.host.ipfw_enabled is True:
+            exec_start += ["set +e", "service ipfw onestop", "set -e"]
+
         if self.config["vnet"]:
             _created, _start = self._start_vimage_network()
             exec_created += _created
@@ -1718,9 +1721,13 @@ class JailGenerator(JailResource):
             ]
         ))
 
-        _ipfw_enabled = self.host.ipfw_enabled
         self._write_hook_script("command", "\n".join(
-            (["set +e", "service ipfw onestop"] if _ipfw_enabled else []) + [
+            (
+                [
+                    "set +e",
+                    "/usr/sbin/service ipfw onestop"
+                ] if self.host.ipfw_enabled else []
+            ) + [
                 "set -e",
                 f". {self._relative_hook_script_dir}/start.sh",
                 jail_command,

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1488,7 +1488,7 @@ class JailGenerator(JailResource):
         jid = self.jid
         try:
             libjail.dll.jail_remove(jid)
-            while libjail.is_jid_dying(jid) is True:
+            while self.running or (libjail.is_jid_dying(jid) is True):
                 # wait for death
                 continue
             self.__jid = None

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1067,14 +1067,12 @@ class JailGenerator(JailResource):
 
         if _stop_jail is True:
             try:
-                stop_events = JailGenerator.stop(
+                yield from JailGenerator.stop(
                     self,
                     force=True,
                     event_scope=event_scope,
                     log_errors=(force_stop is False)
                 )
-                for event in stop_events:
-                    yield event
             except libioc.errors.JailDestructionFailed:
                 pass
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage Jail module."""
 import typing
+import ctypes
 import os
 import random
 import shlex
@@ -2090,10 +2091,14 @@ class JailGenerator(JailResource):
         ))
 
         error = False
+
+        umount_flags = ctypes.c_ulonglong(0x80000)
+
         for mountpoint in (fstab_destinations + system_mountpoints):
             if os.path.ismount(mountpoint) is False:
                 continue
-            if libjail.dll.unmount(mountpoint.encode("utf-8")) == 0:
+            _mountpoint = mountpoint.encode("utf-8")
+            if libjail.dll.unmount(_mountpoint, umount_flags) == 0:
                 self.logger.verbose(f"{mountpoint} successfully unmounted")
             else:
                 error = True

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1489,8 +1489,11 @@ class JailGenerator(JailResource):
 
         jid = self.jid
         try:
-            libjail.dll.jail_remove(self.jid)
-            self.query_jid()
+            libjail.dll.jail_remove(jid)
+            while libjail.is_jid_dying(jid) is True:
+                # wait for death
+                continue
+            self.__jid = None
             yield jailRemoveEvent.end()
             return
         except Exception:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -886,7 +886,7 @@ class JailGenerator(JailResource):
                 yield event.fail(f"exited with {code}")
                 raise libioc.errors.JailHookFailed(
                     jail=self,
-                    hook="prestop",
+                    hook=hook,
                     logger=self.logger
                 )
         else:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -565,6 +565,7 @@ class JailGenerator(JailResource):
                 stdout, stderr, returncode = self._launch_persistent_jail(
                     passthru=passthru
                 )
+                self.query_jid()
             else:
                 stdout, stderr, returncode = self._launch_single_command_jail(
                     single_command,

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -674,10 +674,6 @@ class JailGenerator(JailResource):
             started_jails=started_jails
         )
 
-    def _run_poststop_hook_manually(self) -> None:
-        self.logger.debug("Running poststop hook manually")
-        libioc.helpers.exec(self.get_hook_script_path("poststop"))
-
     def _wrap_jail_command(
         self,
         commands: typing.Optional[typing.List[str]]
@@ -945,35 +941,6 @@ class JailGenerator(JailResource):
         self._ensure_script_dir()
         with open(self.script_env_path, "w") as f:
             f.write(f"export IOC_JID={self.jid}")
-
-    def _write_jail_conf(self, force: bool=False) -> None:
-        if force is True:
-            stop_command = "/usr/bin/true"
-        else:
-            stop_command = (
-                f"[ -f \"{self._relative_hook_script_dir}/stop.sh\" ]"
-                " || exit 0; "
-                f". {self._relative_hook_script_dir}/stop.sh"
-            )
-
-        content = "\n".join([
-            self.identifier + " {",
-            (
-                "exec.prestop = "
-                f"\"/bin/sh {self.get_hook_script_path('prestop')}\";"
-            ), (
-                "exec.poststop = "
-                f"\"/bin/sh {self.get_hook_script_path('poststop')}\";"
-            ), (
-                f"exec.stop = \"{stop_command}\";"
-            ), (
-                f"exec.jail_user = {self._get_value('exec_jail_user')};"
-            ),
-            "}"
-        ])
-        self.logger.debug(f"Writing jail.conf file to {self._jail_conf_file}")
-        with open(self._jail_conf_file, "w") as f:
-            f.write(content)
 
     @property
     def _jail_conf_file(self) -> str:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -570,7 +570,12 @@ class JailGenerator(JailResource):
                     single_command,
                     passthru=passthru
                 )
-            self.query_jid()
+                scope = jailLaunchEvent.scope
+                yield from self.__destroy_jail(scope)
+                yield from self.__run_hook("poststop", False, scope)
+                yield from self.__teardown_mounts(False, scope)
+                yield from self.__clear_resource_limits(False, scope)
+
             if returncode != 0:
                 raise libioc.errors.JailLaunchFailed(
                     jail=self,

--- a/libioc/ZFSShareStorage.py
+++ b/libioc/ZFSShareStorage.py
@@ -51,33 +51,6 @@ class ZFSShareStorage:
         self.logger.verbose("Mounting ZFS shares")
         self._mount_jail_datasets(auto_create=auto_create)
 
-    def umount_zfs_shares(self) -> None:
-        """Unmount a running jails shared ZFS datasets."""
-        for dataset in self.get_zfs_datasets():
-            self.logger.verbose(f"Unmounting ZFS Dataset {dataset.name}")
-            self._exec([
-                "/sbin/zfs",
-                "set",
-                "jailed=off",
-                shlex.quote(dataset.name)
-            ])
-            self._exec([
-                "/sbin/zfs",
-                "umount",
-                shlex.quote(dataset.name)
-            ])
-            self._exec([
-                "/sbin/zfs",
-                "mount",
-                shlex.quote(dataset.name)
-            ])
-            self._exec([
-                "/sbin/zfs",
-                "set",
-                "jailed=on",
-                shlex.quote(dataset.name)
-            ])
-
     def get_zfs_datasets(
         self,
         auto_create: bool=False

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -211,6 +211,20 @@ class JailNotTemplate(JailException):
         JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
+class JailHookFailed(JailException):
+    """Raised when the jail could not be launched."""
+
+    def __init__(
+        self,
+        jail: 'libioc.Jail.JailGenerator',
+        hook: str,
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+        self.hook = hook
+        msg = f"Jail {jail.full_name} hook {hook} failed"
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
+
+
 class JailLaunchFailed(JailException):
     """Raised when the jail could not be launched."""
 
@@ -458,6 +472,18 @@ class ResourceLimitUnknown(IocException, KeyError):
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
         msg = f"The specified resource limit is unknown"
+        IocException.__init__(self, message=msg, logger=logger)
+
+
+class ResourceLimitActionFailed(IocException, KeyError):
+    """Raised when a resource limit has is unknown."""
+
+    def __init__(
+        self,
+        action: str,
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+        msg = f"Resource Limit failed to {action}"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -733,12 +759,15 @@ class UnmountFailed(IocException):
 
     def __init__(
         self,
-        mountpoint: typing.Any,
+        mountpoint: typing.Any=None,
         reason: typing.Optional[str]=None,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
 
-        msg = f"Unmount of {mountpoint} failed"
+        if mountpoint is None:
+            msg = "Umount failed"
+        else:
+            msg = f"Unmount of {mountpoint} failed"
         if reason is not None:
             msg += f": {reason}"
         super().__init__(message=msg, logger=logger)

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -343,17 +343,52 @@ class JailRename(JailEvent):
         JailEvent.__init__(self, jail=jail, message=message, scope=scope)
 
 
-class JailDestroy(JailEvent):
+class JailStop(JailEvent):
     """Destroy the jail."""
 
-    def __init__(
-        self,
-        jail: 'libioc.Jail.JailGenerator',
-        message: typing.Optional[str]=None,
-        scope: typing.Optional[Scope]=None
-    ) -> None:
+    pass
 
-        JailEvent.__init__(self, jail=jail, message=message, scope=scope)
+
+class JailRemove(JailEvent):
+    """Remove the jail(2)."""
+
+    pass
+
+
+class TeardownJailMounts(JailStop):
+    """Teardown a jails mountpoints."""
+
+    pass
+
+
+class JailResourceLimitAction(JailEvent):
+    """Set or unset a jails resource limits."""
+
+    pass
+
+
+class JailHook(JailEvent):
+    """Run jail hook."""
+
+    pass
+
+
+class JailHookPrestop(JailHook):
+    """Run jail prestop hook."""
+
+    pass
+
+
+class JailHookStop(JailHook):
+    """Run jail prestop hook."""
+
+    pass
+
+
+class JailHookPoststop(JailHook):
+    """Run jail prestop hook."""
+
+    pass
 
 
 class JailFstabUpdate(JailEvent):

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -361,6 +361,12 @@ class TeardownJailMounts(JailStop):
     pass
 
 
+class TeardownJailNetwork(JailStop):
+    """Teardown a jails mountpoints."""
+
+    pass
+
+
 class JailResourceLimitAction(JailEvent):
     """Set or unset a jails resource limits."""
 
@@ -925,6 +931,7 @@ class JailCommandExecution(JailEvent):
         """Successfully finish an event."""
         self.stdout = stdout
         return IocEvent.end(self, message)
+
 
 # PKG
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ucl==0.8.0
 gitpython
 freebsd_sysctl==0.0.5
-jail==0.0.4
+jail==0.0.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,8 @@ def new_jail(
         zfs=zfs
     )
     yield new_jail
-    new_jail.destroy(force=True)
+    new_jail.stop(force=True)
+    new_jail.destroy()
 
 
 @pytest.fixture(scope="function")
@@ -208,7 +209,7 @@ def existing_jail(
     local_release: 'libioc.Release.ReleaseGenerator',
 ) -> 'libioc.Jail.Jail':
     new_jail.create(local_release)
-    return new_jail
+    yield new_jail
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,15 @@ def new_jail(
 
 
 @pytest.fixture(scope="function")
+def existing_jail(
+    new_jail: 'libioc.Jail.Jail',
+    local_release: 'libioc.Release.ReleaseGenerator',
+) -> 'libioc.Jail.Jail':
+    new_jail.create(local_release)
+    return new_jail
+
+
+@pytest.fixture(scope="function")
 def bridge_interface() -> str:
     bridge_name = "bridgeTest" + str(random.randint(1024, 4096))
     subprocess.check_output(

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -188,6 +188,11 @@ class TestNullFSBasejail(object):
         existing_jail.stop()
         assert existing_jail.running is False
 
+        with pytest.raises(subprocess.CalledProcessError):
+            stdout = subprocess.check_output(
+                [f"/usr/sbin/jls", "-j", existing_jail.identifier]
+            ).decode("utf-8")
+
         root_path = existing_jail.root_dataset.name
         stdout = subprocess.check_output(
             [f"/sbin/mount | grep {root_path}"],

--- a/tests/test_VNET.py
+++ b/tests/test_VNET.py
@@ -37,20 +37,19 @@ class TestVNET(object):
 
     def test_vnet_without_interfaces_can_only_see_lo0(
         self,
-        new_jail: 'libioc.Jail.Jail',
-        local_release: 'libioc.Release.ReleaseGenerator'
+        existing_jail: 'libioc.Jail.Jail'
     ) -> None:
         """Test if a VNET jail without interfaces can only see lo0."""
-        new_jail.config["vnet"] = True
-        new_jail.create(local_release)
+        existing_jail.config["vnet"] = True
+        existing_jail.save()
 
-        assert len(list(new_jail.networks)) == 0
+        assert len(list(existing_jail.networks)) == 0
 
-        new_jail.start()
+        existing_jail.start()
 
         stdout_lines = subprocess.check_output(
-            ["/usr/sbin/jexec", str(new_jail.jid), "/sbin/ifconfig"]
-        ).decode().split("\n")
+            ["/usr/sbin/jexec", str(existing_jail.jid), "/sbin/ifconfig"]
+        ).decode("utf-8").split("\n")
 
         # filter lines that begin with a whitespace
         configured_nics = [
@@ -64,23 +63,25 @@ class TestVNET(object):
 
     def test_static_ip_configuration(
         self,
-        new_jail: 'libioc.Jail.Jail',
-        local_release: 'libioc.Release.ReleaseGenerator',
+        existing_jail: 'libioc.Jail.Jail',
         bridge_interface: str
     ) -> None:
         """Test if static IPv4 and IPv6 addresses can be configured."""
-        new_jail.config["vnet"] = True
-        new_jail.config["interfaces"] = f"vnet23:{bridge_interface}"
-        new_jail.config["ip4_addr"] = f"vnet23|172.16.99.23/24"
-        new_jail.create(local_release)
+        existing_jail.config["vnet"] = True
+        existing_jail.config["interfaces"] = f"vnet23:{bridge_interface}"
+        existing_jail.config["ip4_addr"] = f"vnet23|172.16.99.23/24"
+        existing_jail.save()
 
-        assert len(list(new_jail.networks)) == 1
+        assert len(list(existing_jail.networks)) == 1
 
-        new_jail.start()
+        existing_jail.start()
 
-        stdout = subprocess.check_output(
-            ["/usr/sbin/jexec", str(new_jail.jid), "/sbin/ifconfig", "vnet23"]
-        ).decode()
+        stdout = subprocess.check_output([
+            "/usr/sbin/jexec",
+            str(existing_jail.jid),
+            "/sbin/ifconfig",
+            "vnet23"
+        ]).decode("utf-8")
 
         # filter lines that begin with a whitespace
         assert "172.16.99.23" in stdout


### PR DESCRIPTION
closes #679 

- gives fine grained access to Jail stop events 
- no longer required launch-scripts to stop a jail 

```
# python3.6 . stop test
[+] JailStop@test: OK [0.284s]
  [+] JailHookPrestop@test: SKIPPED [0.0s]
  [+] JailHookStop@test: OK [0.133s]
  [+] JailRemove@test: OK [0.001s]
  [+] JailHookPoststop@test: OK [0.023s]
  [+] TeardownJailMounts@test: OK [0.083s]
  [+] JailResourceLimitAction@test: SKIPPED [0.001s]
test stopped
```