### PR TITLE
Fix VNET MAC address setting

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -823,7 +823,7 @@ class BaseConfig(dict):
         special_properties = libioc.Config.Jail.Properties.properties
         return list(properties.union(special_properties))
 
-    def _key_is_mac_config(self, key: str, explicit: bool=False) -> bool:
+    def _key_is_mac_config(self, key: str, explicit: bool=True) -> bool:
         fragments = key.rsplit("_", maxsplit=1)
         if len(fragments) < 2:
             return False

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -727,7 +727,7 @@ class BaseConfig(dict):
         existed_before = (key in self.keys()) is True
 
         try:
-            hash_before = str(self.__getitem__(key)).__hash__()
+            hash_before = str(BaseConfig.__getitem__(self, key)).__hash__()
         except Exception:
             if existed_before is True:
                 raise

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -747,6 +747,27 @@ class BaseConfig(dict):
 
         return (hash_before != hash_after) is True
 
+    def set_dict(
+        self,
+        data: typing.Dict[str, typing.Any],
+        skip_on_error: bool=False
+    ) -> typing.Tuple[str, ...]:
+        """
+        Set a dict of jail config properties.
+
+        Returns a list of updated properties.
+        """
+        updated_properties = set()
+        for key in sorted(data.keys(), key=self.__sort_config_keys):
+            if self.set(key, data[key], skip_on_error=skip_on_error) is True:
+                updated_properties.add(key)
+        return updated_properties
+
+    @staticmethod
+    def __sort_config_keys(key) -> int:
+        """Penalizes certain config keys, so that they are always set later."""
+        return 1 if key.endswith("_mac") else 0
+
     def __str__(self) -> str:
         """Return the JSON object with all user configured settings."""
         return str(libioc.helpers.to_json(self.data.nested))

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1614,7 +1614,10 @@ class JailGenerator(JailResource):
                 continue
             else:
                 config_property_name = sysctl.iocage_name
-                if self.config._is_known_property(config_property_name):
+                if self.config._is_known_property(
+                    config_property_name,
+                    explicit=False
+                ) is True:
                     value = config[config_property_name]
                 else:
                     continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def local_release(
 def new_jail(
     host: 'libioc.Host.Host',
     logger: 'libioc.Logger.Logger',
-    zfs: libzfs.ZFS,
+    zfs: libzfs.ZFS
 ) -> 'libioc.Jail.Jail':
     jail_name = "new-jail-" + str(random.randint(1, 32768))
     new_jail = libioc.Jail.Jail(

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -91,6 +91,28 @@ class TestJailConfig(object):
 		with pytest.raises(libioc.errors.InvalidJailName):
 			new_jail.config.clone(invalid_data)
 
+	def test_can_only_set_vnet_mac_when_the_interface_exists(
+		self,
+		new_jail: 'libioc.Jail.Jail'
+	) -> None:
+		with pytest.raises(libioc.errors.UnknownConfigProperty):
+			new_jail.config["vnet0_mac"] = "63ECAC12D0F5"
+
+		new_jail.config["vnet"] = True
+		new_jail.config["interfaces"] = "vnet0:bridge0"
+		new_jail.config["vnet0_mac"] = "63ECAC12D0F6"
+		assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F6"
+
+	def test_order_of_mac_and_interfaces_does_not_matter(
+		self,
+		new_jail: 'libioc.Jail.Jail'
+	) -> None:
+		new_jail.config.set_dict(dict(
+			vnet0_mac="63ECAC12D0F7",
+			interfaces="vnet0:bridge0"
+		))
+		assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F7"
+
 
 class TestUserDefaultConfig(object):
 


### PR DESCRIPTION
fixes #688 

- do not print error message when setting `<NIC>_mac` for the first time
- be strict when setting VNET interface mac addresses, but permissive when reading config files
