### PR TITLE
Start jails with libc jail_set

### DIFF
--- a/libioc/BridgeInterface.py
+++ b/libioc/BridgeInterface.py
@@ -24,7 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage host bridge interface module."""
 import typing
-import shlex
 
 
 class BridgeInterface:
@@ -39,8 +38,7 @@ class BridgeInterface:
     def __init__(
         self,
         name: str,
-        secure_vnet: typing.Optional[bool]=None,
-        insecure: bool=False
+        secure_vnet: typing.Optional[bool]=None
     ) -> None:
         """
         Initialize a (Secure VNET) bridge interface.
@@ -66,8 +64,7 @@ class BridgeInterface:
             self.secure_vnet = (secure_vnet or (secure_vnet is None)) is False
             _name = name
 
-        self.insecure = (insecure is True)
-        self.name = self._escape(_name)
+        self.name = _name
 
         # may override name set secure_vnet mode
         if secure_vnet is not None:
@@ -81,10 +78,6 @@ class BridgeInterface:
         used to mitigate ARP spoofing with IPFW.
         """
         if self.secure_vnet is True:
-            output = f"{self.SECURE_BRIDGE_PREFIX}{self.name}"
+            return f"{self.SECURE_BRIDGE_PREFIX}{self.name}"
         else:
-            output = self.name
-        return self._escape(output)
-
-    def _escape(self, value: str) -> str:
-        return value if self.insecure else str(shlex.quote(value))
+            return self.name

--- a/libioc/JailParams.py
+++ b/libioc/JailParams.py
@@ -114,7 +114,7 @@ class JailParams(collections.abc.MutableMapping):
     """Collection of jail parameters."""
 
     __base_class = JailParam
-    __sysctl_params: typing.Dict[str, freebsd_sysctl.Sysctl]
+    __sysctl_params: typing.Dict[str, JailParam]
 
     def __iter__(self) -> typing.Iterator[str]:
         """Iterate over the jail param names."""
@@ -124,7 +124,7 @@ class JailParams(collections.abc.MutableMapping):
         """Return the number of available jail params."""
         return self.memoized_params.__len__()
 
-    def items(self) -> typing.ItemsView[str, freebsd_sysctl.Sysctl]:
+    def items(self) -> typing.ItemsView[str, JailParam]:
         """Iterate over the keys and values."""
         return self.memoized_params.items()
 
@@ -145,7 +145,7 @@ class JailParams(collections.abc.MutableMapping):
         self.memoized_params.__delitem__(key)
 
     @property
-    def memoized_params(self) -> typing.Dict[str, freebsd_sysctl.Sysctl]:
+    def memoized_params(self) -> typing.Dict[str, JailParam]:
         """Return the memorized params initialized on first access."""
         try:
             return self.__sysctl_params

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -727,7 +727,7 @@ class ReleaseGenerator(ReleaseResource):
             yield releasePrepareStorageEvent.end()
             yield releaseDownloadEvent.begin()
             try:
-                yield from self._fetch_assets()
+                yield from self._fetch_assets(releaseDownloadEvent.scope)
             except Exception:
                 yield releaseDownloadEvent.fail()
                 raise
@@ -891,12 +891,14 @@ class ReleaseGenerator(ReleaseResource):
         self.logger.debug(f"Hashes downloaded to {path}")
 
     def _fetch_assets(
-        self
+        self,
+        event_scope: typing.Optional['libioc.events.Scope']=None,
     ) -> typing.Generator['libioc.events.IocEvent', None, None]:
         for asset in self.assets:
 
             releaseAssetDownloadEvent = libioc.events.ReleaseAssetDownload(
-                release=self
+                release=self,
+                scope=event_scope
             )
             yield releaseAssetDownloadEvent.begin()
             url = f"{self.remote_url}/{asset}.txz"

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -192,7 +192,9 @@ class Updater:
         os.makedirs(directory)
 
     def _clean_create_dir(self, directory: str) -> None:
-        if os.path.isdir(directory):
+        if os.path.ismount(directory) is True:
+            libioc.helpers.umount(directory, force=True, logger=self.logger)
+        if os.path.isdir(directory) is True:
             self.logger.verbose(f"Deleting existing directory {directory}")
             shutil.rmtree(directory)
         self._create_dir(directory)
@@ -425,10 +427,10 @@ class Updater:
                 start_dependant_jails=False,
                 event_scope=_scope
             ):
-                if isinstance(event, libioc.events.JailLaunch) is True:
-                    if event.done is True:
+                if isinstance(event, libioc.events.JailCommand) is True:
+                    if (event.done is True) and (event.error is None):
                         _skipped_text = "No updates are available to install."
-                        skipped = (_skipped_text in event.stdout)
+                        skipped = (_skipped_text in event.stdout) is True
                 yield event
             self.logger.debug(
                 f"Update of resource '{self.resource.name}' finished"

--- a/libioc/Storage/Basejail.py
+++ b/libioc/Storage/Basejail.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2017-2019, Stefan Grönke
-# Copyright (c) 2014-2018, iocage
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -22,32 +21,44 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""iocage standalone jail storage backend."""
+"""Shared code of various Basejail implementations (NullFS, ZFS)."""
 import typing
 
-import libioc.Storage
+import libioc.Types
+import libioc.Release
 
 
-class StandaloneJailStorage(libioc.Storage.Storage):
-    """iocage standalone jail storage backend."""
+class BasejailStorage(libioc.Storage.Storage):
+    """Prototype class of Basejail Storage."""
 
-    def apply(
-        self,
-        release: 'libioc.Release.ReleaseGenerator'=None,
-        event_scope: typing.Optional['libioc.events.Scope']=None
-    ) -> typing.Generator['libioc.events.IocEvent', None, None]:
-        """Attach the jail storage."""
-        message = "Standalone jails do not require storage operations to start"
-        self.logger.warn(
-            message,
-            jail=self.jail
+    def _get_basejail_mounts(self) -> typing.Iterator[
+        typing.Tuple[libioc.Types.AbsolutePath, libioc.Types.AbsolutePath]
+    ]:
+        """
+        Auto-generate lines of NullFS basejails.
+
+        When a jail is a NullFS basejail, this list represent the corresponding
+        fstab lines that mount the release.
+
+        Return a list of tuples (source, destination,).
+        """
+        try:
+            self.jail.release
+        except AttributeError:
+            return []
+
+        if self.jail.config["basejail_type"] != "nullfs":
+            return []
+
+        basedirs = libioc.helpers.get_basedir_list(
+            distribution_name=self.jail.host.distribution.name
         )
-        raise NotImplementedError(message)
 
-    def setup(
-        self,
-        resource: 'libioc.Resource.Resource'
-    ) -> None:
-        """Configure the jail storage."""
-        self.logger.verbose("Cloning the release once to the root dataset")
-        self.clone_resource(resource)
+        release_root_path = "/".join([
+            self.jail.release.root_dataset.mountpoint,
+            f".zfs/snapshot/{self.jail.release_snapshot.snapshot_name}"
+        ])
+        for basedir in basedirs:
+            source = f"{release_root_path}/{basedir}"
+            destination = f"{self.jail.root_dataset.mountpoint}/{basedir}"
+            yield (source, destination,)

--- a/libioc/Storage/NullFSBasejail.py
+++ b/libioc/Storage/NullFSBasejail.py
@@ -23,48 +23,99 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage NullFS basejail storage backend."""
+import typing
+import os.path
+
 import libioc.Storage
+import libioc.Storage.Basejail
 import libioc.Storage.Standalone
 import libioc.helpers
 
+BasejailStorage = libioc.Storage.Basejail.BasejailStorage
 
-class NullFSBasejailStorage(libioc.Storage.Storage):
+
+class NullFSBasejailStorage(libioc.Storage.Basejail.BasejailStorage):
     """iocage NullFS basejail storage backend."""
 
-    def apply(self, release=None):
+    def apply(
+        self,
+        release: 'libioc.Release.ReleaseGenerator'=None,
+        event_scope: typing.Optional['libioc.events.Scope']=None
+    ) -> typing.Generator['libioc.events.IocEvent', None, None]:
         """Attach the jail storage."""
-        NullFSBasejailStorage._create_nullfs_directories(self)
+        event = libioc.events.BasejailStorageConfig(
+            jail=self.jail,
+            scope=event_scope
+        )
+        yield event.begin()
 
-    def setup(self, release):
+        try:
+            NullFSBasejailStorage._create_nullfs_directories(self)
+        except Exception:
+            yield event.fail("NullFS directory creation failed")
+            raise
+
+        try:
+            mounts = BasejailStorage._get_basejail_mounts(self)
+            for source, destination in mounts:
+                if os.path.ismount(destination) is True:
+                    libioc.helpers.umount(destination)
+                libioc.helpers.mount(
+                    source=source,
+                    destination=destination,
+                    fstype="nullfs",
+                    opts=["ro"]
+                )
+        except Exception:
+            yield event.fail("Failed to mount NullFS basedirs")
+            raise
+
+        yield event.end()
+
+    def teardown(
+        self,
+        event_scope: typing.Optional['libioc.events.Scope']=None
+    ) -> typing.Generator['libioc.events.IocEvent', None, None]:
+        """Unmount NullFS basejail mounts."""
+        event = libioc.events.BasejailStorageConfig(
+            jail=self.jail,
+            scope=event_scope
+        )
+        yield event.begin()
+
+        has_unmounted_any = False
+        try:
+            mounts = BasejailStorage._get_basejail_mounts(self)
+            for _, destination in mounts:
+                if os.path.ismount(destination) is False:
+                    continue
+                libioc.helpers.umount(destination, force=True)
+                has_unmounted_any = True
+        except Exception:
+            yield event.fail("Failed to mount NullFS basedirs")
+            raise
+
+        if has_unmounted_any is False:
+            yield event.skip()
+        else:
+            yield event.end()
+
+        yield from libioc.Storage.Storage.teardown(
+            self,
+            event_scope=event_scope
+        )
+
+    def setup(
+        self,
+        release: 'libioc.Release.ReleaseGenerator'=None
+    ) -> None:
         """Prepare the jail storage."""
         libioc.Storage.Standalone.StandaloneJailStorage.setup(
             self,
             release
         )
 
-    def umount_nullfs(self):
-        """
-        Unmount all NullFS mounts from fstab.
-
-        In preparation of starting the jail with NullFS mounts all mountpoints
-        that are listed in fstab need to be unmounted
-        """
-        with open(f"{self.jail.path}/fstab") as f:
-            mounts = []
-            for mount in f.read().splitlines():
-                mount_line_data = mount.replace("\t", " ").split()
-                if len(mount_line_data) > 2:
-                    # line has a mountpoint
-                    mounts.append(mount_line_data[1])
-
-            if (len(mounts) > 0):
-                try:
-                    libioc.helpers.exec(["/sbin/umount"] + mounts)
-                except libioc.errors.CommandFailure:
-                    # in case directories were not mounted
-                    pass
-
-    def _create_nullfs_directories(self):
+    def _create_nullfs_directories(self) -> None:
         basedirs = libioc.helpers.get_basedir_list(
             distribution_name=self.jail.host.distribution.name
         ) + ["dev", "etc"]

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -779,10 +779,26 @@ class MountFailed(IocException):
     def __init__(
         self,
         mountpoint: libioc.Types.AbsolutePath,
+        reason: typing.Optional[str]=None,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
 
         msg = f"Failed to mount {mountpoint}"
+        if reason is not None:
+            msg += f": {reason}"
+        super().__init__(message=msg, logger=logger)
+
+
+class InvalidMountpoint(IocException):
+    """Raised when a mountpoint was invalid or not found."""
+
+    def __init__(
+        self,
+        mountpoint: libioc.Types.AbsolutePath,
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+
+        msg = f"Invalid mountpoint {mountpoint}"
         super().__init__(message=msg, logger=logger)
 
 

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -299,30 +299,6 @@ class JailEvent(IocEvent):
         IocEvent.__init__(self, message=message, scope=scope)
 
 
-class JailLaunch(JailEvent):
-    """Launch a jail."""
-
-    stdout: typing.Optional[str]
-
-    def __init__(
-        self,
-        jail: 'libioc.Jail.JailGenerator',
-        message: typing.Optional[str]=None,
-        scope: typing.Optional[Scope]=None
-    ) -> None:
-        self.stdout = None
-        JailEvent.__init__(self, jail=jail, message=message, scope=scope)
-
-    def end(
-        self,
-        message: typing.Optional[str]=None,
-        stdout: str=""
-    ) -> 'IocEvent':
-        """Successfully finish an event."""
-        self.stdout = stdout
-        return IocEvent.end(self, message)
-
-
 class JailRename(JailEvent):
     """Change the name of a jail."""
 
@@ -355,7 +331,7 @@ class JailRemove(JailEvent):
     pass
 
 
-class TeardownJailMounts(JailStop):
+class TeardownSystemMounts(JailStop):
     """Teardown a jails mountpoints."""
 
     pass
@@ -373,8 +349,140 @@ class JailResourceLimitAction(JailEvent):
     pass
 
 
+class VnetEvent(JailEvent):
+    """A group of events around VNET operations."""
+
+    pass
+
+
+class VnetSetup(VnetEvent):
+    """Start VNET networks."""
+
+    pass
+
+
+class VnetTeardown(VnetEvent):
+    """Teardown VNET networks."""
+
+    pass
+
+
+class VnetInterfaceConfig(VnetSetup):
+    """Configure VNET network interfaces and firewall."""
+
+    pass
+
+
+class JailAttach(JailEvent):
+    """Remove the jail(2)."""
+
+    pass
+
+
+class DevFSEvent(JailEvent):
+    """Group of events that occor on DevFS operations."""
+
+    pass
+
+
+class MountDevFS(DevFSEvent):
+    """Mount /dev into a jail."""
+
+    pass
+
+
+class UnmountDevFS(DevFSEvent):
+    """Unmount /dev from a jail."""
+
+    pass
+
+
+class FstabEvent(JailEvent):
+    """Group of events that occor on Fstab operations."""
+
+    pass
+
+
+class MountFstab(FstabEvent):
+    """Mount entries from a jails fstab file."""
+
+    pass
+
+
+class UnmountFstab(FstabEvent):
+    """Unmount entries from a jails fstab file."""
+
+    pass
+
+
 class JailHook(JailEvent):
     """Run jail hook."""
+
+    stdout: typing.Optional[str]
+
+    def __init__(
+        self,
+        jail: 'libioc.Jail.JailGenerator',
+        message: typing.Optional[str]=None,
+        scope: typing.Optional[Scope]=None
+    ) -> None:
+
+        self.stdout = None
+        super().__init__(
+            jail=jail,
+            message=message,
+            scope=scope
+        )
+
+    def end(
+        self,
+        message: typing.Optional[str]=None,
+        stdout: str=""
+    ) -> 'IocEvent':
+        """Successfully finish an event."""
+        self.stdout = stdout
+        return super().end(message)
+
+    def fail(
+        self,
+        exception: bool=True,
+        message: typing.Optional[str]=None,
+        stdout: str=""
+    ) -> 'IocEvent':
+        """Successfully finish an event."""
+        self.stdout = stdout
+        return super().fail(
+            exception=exception,
+            message=message
+        )
+
+
+class JailHookPrestart(JailHook):
+    """Run jail prestart hook."""
+
+    pass
+
+
+class JailHookStart(JailHook):
+    """Run jail start hook."""
+
+    pass
+
+
+class JailCommand(JailHook):
+    """Run command in a jail."""
+
+    pass
+
+
+class JailHookCreated(JailHook):
+    """Run jail created hook."""
+
+    pass
+
+
+class JailHookPoststart(JailHook):
+    """Run jail poststart hook."""
 
     pass
 
@@ -386,13 +494,13 @@ class JailHookPrestop(JailHook):
 
 
 class JailHookStop(JailHook):
-    """Run jail prestop hook."""
+    """Run jail stop hook."""
 
     pass
 
 
 class JailHookPoststop(JailHook):
-    """Run jail prestop hook."""
+    """Run jail poststop hook."""
 
     pass
 
@@ -421,6 +529,32 @@ class JailResolverConfig(JailEvent):
     ) -> None:
 
         JailEvent.__init__(self, jail=jail, message=message, scope=scope)
+
+
+class JailZFSShare(JailEvent):
+    """Group of events that mounts or unmounts shared ZFS datasets."""
+
+    pass
+
+
+class BasejailStorageConfig(JailEvent):
+    """Mount or unmount basejail storage of a jail."""
+
+    pass
+
+
+class AttachZFSDataset(JailZFSShare):
+    """Mount an individual dataset when starting a jail with shared ZFS."""
+
+    def __init__(
+        self,
+        jail: 'libioc.Jail.JailGenerator',
+        dataset: libzfs.ZFSDataset,
+        scope: typing.Optional[Scope]=None
+    ) -> None:
+
+        msg = f"Dataset {dataset.name} was attached to Jail {jail.full_name}"
+        JailEvent.__init__(self, jail=jail, message=msg, scope=scope)
 
 
 class JailClone(JailEvent):
@@ -844,12 +978,6 @@ class JailRestart(JailEvent):
     pass
 
 
-class JailShutdown(JailEvent):
-    """Shutdown a jail."""
-
-    pass
-
-
 class JailSoftShutdown(JailEvent):
     """Soft-restart a jail."""
 
@@ -907,30 +1035,6 @@ class JailProvisioningAssetDownload(JailEvent):
     """Provision a jail."""
 
     pass
-
-
-class JailCommandExecution(JailEvent):
-    """Run command in a jail."""
-
-    stdout: typing.Optional[str]
-
-    def __init__(
-        self,
-        jail: 'libioc.Jail.JailGenerator',
-        message: typing.Optional[str]=None,
-        scope: typing.Optional[Scope]=None
-    ) -> None:
-        self.stdout = None
-        JailEvent.__init__(self, jail=jail, message=message, scope=scope)
-
-    def end(
-        self,
-        message: typing.Optional[str]=None,
-        stdout: str=""
-    ) -> 'IocEvent':
-        """Successfully finish an event."""
-        self.stdout = stdout
-        return IocEvent.end(self, message)
 
 
 # PKG

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ucl==0.8.0
 gitpython
 freebsd_sysctl==0.0.5
-jail==0.0.6
+jail==0.0.7

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -87,8 +87,7 @@ class TestJail(object):
             shell=True
         ).decode("utf-8")
 
-        assert "launch-scripts in stdout"
-        assert stdout.strip().count("\n") == 1
+        assert stdout.strip().count("\n") == 0
 
     def test_can_be_stopped(
         self,
@@ -172,7 +171,7 @@ class TestNullFSBasejail(object):
             shell=True
         ).decode("utf-8")
         assert "launch-scripts in stdout"
-        assert stdout.strip().count("\n") == 1 + len(basedirs)
+        assert stdout.strip().count("\n") == len(basedirs)
         for basedir in basedirs:
             assert f"{root_path}/{basedir}" in stdout
 


### PR DESCRIPTION
- Refactoring of the entire start process
  - Individual events for actions and hooks
- Use py-jail to start jails
- (Un)mount NullFS and DevFS with libc
- Deprecate launch helper scripts (`/.iocage` in a jail)
- Do not store basejail directories in a jails fstab file