### PR TITLE
Enhance handling of invalid config

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -172,7 +172,11 @@ class BaseConfig(dict):
         if current_id is not None:
             new_data["id"] = current_id
 
-        self.set_dict(new_data, explicit=False, skip_on_error=False)
+        self.set_dict(
+            new_data,
+            explicit=False,
+            skip_on_error=skip_on_error
+        )
 
     def read(self, data: dict, skip_on_error: bool=False) -> None:
         """
@@ -662,12 +666,15 @@ class BaseConfig(dict):
             self.data[key] = self.__sanitize_value(key, parsed_value)
             error = None
         except ValueError as err:
-            error = libioc.errors.InvalidJailConfigValue(
-                reason=str(err),
-                property_name=key,
-                logger=self.logger,
-                level=("warn" if (skip_on_error is True) else "error")
-            )
+            if isinstance(err, libioc.errors.IocException) is True:
+                error = err
+            else:
+                error = libioc.errors.InvalidJailConfigValue(
+                    reason=str(err),
+                    property_name=key,
+                    logger=self.logger,
+                    level=("warn" if (skip_on_error is True) else "error")
+                )
 
         if (error is not None) and (skip_on_error is False):
             raise error

--- a/libioc/Config/Jail/Defaults.py
+++ b/libioc/Config/Jail/Defaults.py
@@ -57,7 +57,11 @@ class JailConfigDefaults(libioc.Config.Jail.BaseConfig.BaseConfig):
             raise ValueError("expecting Config.Data structure")
         self.user_data = value
 
-    def clone(self, data: typing.Dict[str, typing.Any]) -> None:
+    def clone(
+        self,
+        data: typing.Dict[str, typing.Any],
+        skip_on_error: bool=False
+    ) -> None:
         """Clone data from another dict."""
         for key in data:
             self.user_data[key] = data[key]

--- a/libioc/Config/Jail/Properties/Addresses.py
+++ b/libioc/Config/Jail/Properties/Addresses.py
@@ -160,6 +160,7 @@ class AddressesProp(dict):
         """Set the special property value."""
         self.clear()
         error_log_level = "warn" if (skip_on_error is True) else "error"
+        skip_on_error = (self.skip_on_error or skip_on_error) is True
 
         try:
             libioc.helpers.parse_none(data)

--- a/libioc/Config/Type/JSON.py
+++ b/libioc/Config/Type/JSON.py
@@ -42,8 +42,14 @@ class ConfigJSON(libioc.Config.Prototype.Prototype):
         """Parse and normalize JSON data."""
         if data == "":
             return {}
-        result = json.load(data)  # type: typing.Dict[str, typing.Any]
-        return result
+        try:
+            result = json.load(data)  # type: typing.Dict[str, typing.Any]
+            return result
+        except json.decoder.JSONDecodeError as e:
+            raise libioc.errors.JailConfigError(
+                message=str(e),
+                logger=self.logger
+            )
 
     def map_output(self, data: libioc.Config.Data.Data) -> str:
         """Output configuration data as JSON string."""

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -289,7 +289,8 @@ class JailGenerator(JailResource):
         host: typing.Optional['libioc.Host.Host']=None,
         fstab: typing.Optional['libioc.Config.Jail.File.Fstab.Fstab']=None,
         root_datasets_name: typing.Optional[str]=None,
-        new: bool=False
+        new: bool=False,
+        skip_invalid_config: bool=False
     ) -> None:
         """
         Initialize a Jail.
@@ -354,7 +355,10 @@ class JailGenerator(JailResource):
         )
 
         if new is False:
-            self.config.read(data=self.read_config(), skip_on_error=True)
+            self.config.read(
+                data=self.read_config(),
+                skip_on_error=skip_invalid_config
+            )
             if self.config["id"] is None:
                 self.config["id"] = self.dataset_name.split("/").pop()
 

--- a/libioc/Jails.py
+++ b/libioc/Jails.py
@@ -44,17 +44,22 @@ class JailsGenerator(libioc.ListableResource.ListableResource):
         "ip6.addr"
     ]
 
+    resource_args: typing.Dict[str, typing.Any]
+
     def __init__(
         self,
         filters: typing.Optional[libioc.Filter.Terms]=None,
         host: typing.Optional['libioc.Host.HostGenerator']=None,
         logger: typing.Optional['libioc.Logger.Logger']=None,
-        zfs: typing.Optional['libioc.ZFS.ZFS']=None
+        zfs: typing.Optional['libioc.ZFS.ZFS']=None,
+        **resource_args: typing.Any
     ) -> None:
 
         self.logger = libioc.helpers_object.init_logger(self, logger)
         self.zfs = libioc.helpers_object.init_zfs(self, zfs)
         self.host = libioc.helpers_object.init_host(self, host)
+
+        self.resource_args = resource_args
 
         libioc.ListableResource.ListableResource.__init__(
             self,
@@ -81,7 +86,8 @@ class JailsGenerator(libioc.ListableResource.ListableResource):
             ),
             logger=self.logger,
             host=self.host,
-            zfs=self.zfs
+            zfs=self.zfs,
+            **self.resource_args
         )
 
         return jail

--- a/libioc/ListableResource.py
+++ b/libioc/ListableResource.py
@@ -46,7 +46,7 @@ class ListableResource(list):
         namespace: typing.Optional[str]=None,
         filters: typing.Optional['libioc.Filter.Terms']=None,
         logger: typing.Optional['libioc.Logger.Logger']=None,
-        zfs: typing.Optional['libioc.ZFS.ZFS']=None,
+        zfs: typing.Optional['libioc.ZFS.ZFS']=None
     ) -> None:
 
         list.__init__(self, [])

--- a/libioc/Resource.py
+++ b/libioc/Resource.py
@@ -327,7 +327,10 @@ class Resource(metaclass=abc.ABCMeta):
         """Write the configuration to disk."""
         self.config_handler.write(data)
 
-    def read_config(self) -> typing.Dict[str, typing.Any]:
+    def read_config(
+        self,
+        skip_invalid: bool=False
+    ) -> typing.Dict[str, typing.Any]:
         """Read the configuration from disk."""
         data = self.config_handler.read()  # type: typing.Dict[str, typing.Any]
         return data
@@ -416,7 +419,10 @@ class DefaultResource(Resource):
             logger=logger
         )
 
-    def read_config(self) -> typing.Dict[str, typing.Any]:
+    def read_config(
+        self,
+        skip_invalid: bool=False
+    ) -> typing.Dict[str, typing.Any]:
         """Read the default configuration."""
         o = Resource.read_config(self)
         self.config.clone(o)

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -267,13 +267,22 @@ class TestBrokenConfig(object):
         with open(existing_jail.config_json.file, "w", encoding="UTF-8") as f:
             json.dump(invalid_config_data, f)
 
-        with pytest.raises(libioc.errors.InvalidJailConfigAddress):
+        with pytest.raises(libioc.errors.InvalidJailConfigValue):
             jail = libioc.Jail.Jail(
                 existing_jail.name,
                 host=host,
                 logger=logger,
                 zfs=zfs
             )
+
+        # multiple jails
+        with pytest.raises(libioc.errors.InvalidJailConfigValue):
+            list(libioc.Jails.Jails(
+                existing_jail.name,
+                host=host,
+                logger=logger,
+                zfs=zfs
+            ))
 
     def test_can_optionally_ignore_invalid_config(
         self,
@@ -303,3 +312,15 @@ class TestBrokenConfig(object):
 
         stdout, stderr = capsys.readouterr()
         assert 'expected "<nic>|<address>"' in stdout
+
+        assert len(jail.config["ip4_addr"].keys()) == 0
+        assert "ip4_addr" not in jail.config.data.keys()
+
+        # multiple jails
+        list(libioc.Jails.Jails(
+            existing_jail.name,
+            skip_invalid_config=True,
+            host=host,
+            logger=logger,
+            zfs=zfs
+        ))

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -35,197 +35,222 @@ import libioc.Config.Jail.Properties.Interfaces
 
 class TestJailConfig(object):
 
-	def test_default_config_type_is_json(
-		self,
-		existing_jail: 'libioc.Jail.Jail'
-	) -> None:
-		ConfigJSON = libioc.Config.Type.JSON.ConfigJSON
-		assert existing_jail.config_type == "json"
-		assert isinstance(existing_jail.config_handler, ConfigJSON)
+    def test_default_config_type_is_json(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        ConfigJSON = libioc.Config.Type.JSON.ConfigJSON
+        assert existing_jail.config_type == "json"
+        assert isinstance(existing_jail.config_handler, ConfigJSON)
 
-	def test_cannot_set_unknown_config_property(
-		self,
-		existing_jail: 'libioc.Jail.Jail'
-	) -> None:
-		key = "doesnotexist"
-		with pytest.raises(libioc.errors.UnknownConfigProperty):
-			existing_jail.config[key]
-		assert key not in existing_jail.config.keys()
+    def test_cannot_set_unknown_config_property(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        key = "doesnotexist"
+        with pytest.raises(libioc.errors.UnknownConfigProperty):
+            existing_jail.config[key]
+        assert key not in existing_jail.config.keys()
 
-	def test_can_set_arbitrary_user_config_properties(
-		self,
-		existing_jail: 'libioc.Jail.Jail'
-	) -> None:
+    def test_can_set_arbitrary_user_config_properties(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
 
-		existing_jail.config["user.foobar"] = "baz"
-		existing_jail.save()
+        existing_jail.config["user.foobar"] = "baz"
+        existing_jail.save()
 
-		assert "user.foobar" in existing_jail.config.keys()
-		assert isinstance(existing_jail.config["user"], dict)
-		assert "foobar" in existing_jail.config["user"].keys()
-		assert existing_jail.config["user"]["foobar"] == "baz"
+        assert "user.foobar" in existing_jail.config.keys()
+        assert isinstance(existing_jail.config["user"], dict)
+        assert "foobar" in existing_jail.config["user"].keys()
+        assert existing_jail.config["user"]["foobar"] == "baz"
 
-		with open(existing_jail.config_json.file, "r", encoding="UTF-8") as f:
-			data = json.load(f)
+        with open(existing_jail.config_json.file, "r", encoding="UTF-8") as f:
+            data = json.load(f)
 
-		assert "user" in data.keys()
-		assert isinstance(data["user"], dict)
-		assert "foobar" in data["user"].keys()
-		assert isinstance(data["user"]["foobar"], str)
+        assert "user" in data.keys()
+        assert isinstance(data["user"], dict)
+        assert "foobar" in data["user"].keys()
+        assert isinstance(data["user"]["foobar"], str)
 
-	def test_name_may_not_contain_dots(
-		self,
-		existing_jail: 'libioc.Jail.Jail'
-	) -> None:
-		with pytest.raises(libioc.errors.InvalidJailName):
-			existing_jail.config["name"] = "jail.with.dots"
+    def test_name_may_not_contain_dots(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        with pytest.raises(libioc.errors.InvalidJailName):
+            existing_jail.config["name"] = "jail.with.dots"
 
-	def test_cannot_clone_from_dict_with_invalid_values(
-		self,
-		new_jail: 'libioc.Jail.Jail'
-	) -> None:
-		invalid_data = dict(
-			name="name.with.dots"
-		)
-		del new_jail.config["id"]
-		with pytest.raises(libioc.errors.InvalidJailName):
-			new_jail.config.clone(invalid_data)
+    def test_cannot_clone_from_dict_with_invalid_values(
+        self,
+        new_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        invalid_data = dict(
+            name="name.with.dots"
+        )
+        del new_jail.config["id"]
+        with pytest.raises(libioc.errors.InvalidJailName):
+            new_jail.config.clone(invalid_data)
 
-	def test_can_only_set_vnet_mac_when_the_interface_exists(
-		self,
-		new_jail: 'libioc.Jail.Jail'
-	) -> None:
-		with pytest.raises(libioc.errors.UnknownConfigProperty):
-			new_jail.config["vnet0_mac"] = "63ECAC12D0F5"
+    def test_can_only_set_vnet_mac_when_the_interface_exists(
+        self,
+        new_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        with pytest.raises(libioc.errors.UnknownConfigProperty):
+            new_jail.config["vnet0_mac"] = "63ECAC12D0F5"
 
-		new_jail.config["vnet"] = True
-		new_jail.config["interfaces"] = "vnet0:bridge0"
-		new_jail.config["vnet0_mac"] = "63ECAC12D0F6"
-		assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F6"
+        new_jail.config["vnet"] = True
+        new_jail.config["interfaces"] = "vnet0:bridge0"
+        new_jail.config["vnet0_mac"] = "63ECAC12D0F6"
+        assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F6"
 
-	def test_order_of_mac_and_interfaces_does_not_matter(
-		self,
-		new_jail: 'libioc.Jail.Jail'
-	) -> None:
-		new_jail.config.set_dict(dict(
-			vnet0_mac="63ECAC12D0F7",
-			interfaces="vnet0:bridge0"
-		))
-		assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F7"
+    def test_order_of_mac_and_interfaces_does_not_matter(
+        self,
+        new_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        new_jail.config.set_dict(dict(
+            vnet0_mac="63ECAC12D0F7",
+            interfaces="vnet0:bridge0"
+        ))
+        assert new_jail.config.data["vnet0_mac"] == "63ECAC12D0F7"
 
-	def test_jails_with_already_existing_unknown_macs_can_be_loaded(
-		self,
-		existing_jail: 'libioc.Jail.Jail',
-		host: 'libioc.Host.Host',
-	    logger: 'libioc.Logger.Logger',
-	    zfs: libzfs.ZFS
-	) -> None:
-		config_file = existing_jail.config_handler.file
-		with open(config_file, "w", encoding="UTF-8") as f:
-			json.dump(dict(
-				name=existing_jail.config["name"],
-				release=existing_jail.config["release"],
-				vnet="yes",
-				vnet0_mac="63ECAC12D0F8",
-				vnet1_mac="63ECAC12D0F9"
-			), f)
+    def test_jails_with_already_existing_unknown_macs_can_be_loaded(
+        self,
+        existing_jail: 'libioc.Jail.Jail',
+        host: 'libioc.Host.Host',
+        logger: 'libioc.Logger.Logger',
+        zfs: libzfs.ZFS
+    ) -> None:
+        config_file = existing_jail.config_handler.file
+        with open(config_file, "w", encoding="UTF-8") as f:
+            json.dump(dict(
+                name=existing_jail.config["name"],
+                release=existing_jail.config["release"],
+                vnet="yes",
+                vnet0_mac="63ECAC12D0F8",
+                vnet1_mac="63ECAC12D0F9"
+            ), f)
 
-		jail = libioc.Jail.Jail(
-			existing_jail.name,
-			host=host,
-			logger=logger,
-			zfs=zfs
-		)
-		assert jail.config["vnet0_mac"] == "63ECAC12D0F8"
-		assert jail.config["vnet1_mac"] == "63ECAC12D0F9"
-		assert "interfaces" not in jail.config.data
-		assert len(jail.config["interfaces"]) == 0
+        jail = libioc.Jail.Jail(
+            existing_jail.name,
+            host=host,
+            logger=logger,
+            zfs=zfs
+        )
+        assert jail.config["vnet0_mac"] == "63ECAC12D0F8"
+        assert jail.config["vnet1_mac"] == "63ECAC12D0F9"
+        assert "interfaces" not in jail.config.data
+        assert len(jail.config["interfaces"]) == 0
 
-		# can start, although config is not explicitly valid
-		jail.start()
-		assert jail.running
+        # can start, although config is not explicitly valid
+        jail.start()
+        assert jail.running
 
 
 class TestUserDefaultConfig(object):
 
-	@pytest.fixture(scope="function")
-	def default_config_file_handler(
-		self,
-		root_dataset: libzfs.ZFSDataset
-	) -> typing.IO[str]:
-		defaults_config_file = f"{root_dataset.mountpoint}/defaults.json"
-		f = open(defaults_config_file, "w", encoding="UTF-8")
-		yield f
+    @pytest.fixture(scope="function")
+    def default_config_file_handler(
+        self,
+        root_dataset: libzfs.ZFSDataset
+    ) -> typing.IO[str]:
+        defaults_config_file = f"{root_dataset.mountpoint}/defaults.json"
+        f = open(defaults_config_file, "w", encoding="UTF-8")
+        yield f
 
-		with open(defaults_config_file, "r") as x:
-			print(x.read())
+        with open(defaults_config_file, "r") as x:
+            print(x.read())
 
-		f.close()
-		os.remove(defaults_config_file)
+        f.close()
+        os.remove(defaults_config_file)
 
-	@pytest.fixture(scope="function")
-	def default_resource(
-		self,
-		logger: 'libioc.Logger.Logger',
-		root_dataset: libzfs.ZFSDataset,
-		zfs: libzfs.ZFS,
-	) -> 'libioc.Resource.DefaultResource':
-		return libioc.Resource.DefaultResource(
-			dataset=root_dataset,
-			logger=logger,
-			zfs=zfs
-		)
+    @pytest.fixture(scope="function")
+    def default_resource(
+        self,
+        logger: 'libioc.Logger.Logger',
+        root_dataset: libzfs.ZFSDataset,
+        zfs: libzfs.ZFS,
+    ) -> 'libioc.Resource.DefaultResource':
+        return libioc.Resource.DefaultResource(
+            dataset=root_dataset,
+            logger=logger,
+            zfs=zfs
+        )
 
-	def test_default_config_path(
-		self,
-		host: 'libioc.Host.HostGenerator',
-		root_dataset: libzfs.ZFSDataset
-	) -> None:
-		assert isinstance(host.defaults, libioc.Resource.DefaultResource)
-		assert "config" in dir(host.defaults)
+    def test_default_config_path(
+        self,
+        host: 'libioc.Host.HostGenerator',
+        root_dataset: libzfs.ZFSDataset
+    ) -> None:
+        assert isinstance(host.defaults, libioc.Resource.DefaultResource)
+        assert "config" in dir(host.defaults)
 
-		host_config_file = host.defaults.config_handler.file
-		assert host_config_file == f"{root_dataset.mountpoint}/defaults.json"
+        host_config_file = host.defaults.config_handler.file
+        assert host_config_file == f"{root_dataset.mountpoint}/defaults.json"
 
-	def test_read_default_config_file(
-		self,
-		default_resource: 'libioc.Resource.DefaultResource',
-		default_config_file_handler: typing.IO[str]
-	) -> None:
-		test_data = dict(vnet="yes", interfaces="vnet5:bridge8")
-		test_data_json = json.dumps(test_data)
-		default_config_file_handler.write(test_data_json)
-		default_config_file_handler.flush()
+    def test_read_default_config_file(
+        self,
+        default_resource: 'libioc.Resource.DefaultResource',
+        default_config_file_handler: typing.IO[str]
+    ) -> None:
+        test_data = dict(vnet="yes", interfaces="vnet5:bridge8")
+        test_data_json = json.dumps(test_data)
+        default_config_file_handler.write(test_data_json)
+        default_config_file_handler.flush()
 
-		default_resource.read_config()
-		assert default_resource.config["vnet"] == True
-		assert isinstance(
-			default_resource.config["interfaces"],
-			libioc.Config.Jail.Properties.Interfaces.InterfaceProp
-		)
-		assert len(default_resource.config["interfaces"]) == 1
-		assert "vnet5" in default_resource.config["interfaces"]
-		assert isinstance(
-			default_resource.config["interfaces"]["vnet5"],
-			libioc.BridgeInterface.BridgeInterface
-		)
-		assert str(default_resource.config["interfaces"]["vnet5"]) == "bridge8"
+        default_resource.read_config()
+        assert default_resource.config["vnet"] == True
+        assert isinstance(
+            default_resource.config["interfaces"],
+            libioc.Config.Jail.Properties.Interfaces.InterfaceProp
+        )
+        assert len(default_resource.config["interfaces"]) == 1
+        assert "vnet5" in default_resource.config["interfaces"]
+        assert isinstance(
+            default_resource.config["interfaces"]["vnet5"],
+            libioc.BridgeInterface.BridgeInterface
+        )
+        assert str(default_resource.config["interfaces"]["vnet5"]) == "bridge8"
 
-	def test_falls_back_to_globals_if_unconfigured(
-		self,
-		default_resource: 'libioc.Resource.DefaultResource',
-	) -> None:
-		assert default_resource.config["vnet"] == False
+    def test_falls_back_to_globals_if_unconfigured(
+        self,
+        default_resource: 'libioc.Resource.DefaultResource',
+    ) -> None:
+        assert default_resource.config["vnet"] == False
 
-	def test_fail_to_read_unknown_property(
-		self,
-		default_resource: 'libioc.Resource.DefaultResource',
-	) -> None:
-		with pytest.raises(libioc.errors.UnknownConfigProperty):
-			default_resource.config["not-available"]
-		with pytest.raises(libioc.errors.UnknownConfigProperty):
-			default_resource.config["not-available"] = "foobar"
+    def test_fail_to_read_unknown_property(
+        self,
+        default_resource: 'libioc.Resource.DefaultResource',
+    ) -> None:
+        with pytest.raises(libioc.errors.UnknownConfigProperty):
+            default_resource.config["not-available"]
+        with pytest.raises(libioc.errors.UnknownConfigProperty):
+            default_resource.config["not-available"] = "foobar"
 
-		# check that valid properties still can be set
-		default_resource.config["user.valid-property"] = "ok"
-		assert default_resource.config.data["user.valid-property"] == "ok"
+        # check that valid properties still can be set
+        default_resource.config["user.valid-property"] = "ok"
+        assert default_resource.config.data["user.valid-property"] == "ok"
+
+
+class TestBrokenConfig(object):
+    """Test the behavior of jails with invalid config."""
+
+    def test_refuse_to_load_jail_with_invalid_json(
+        self,
+        existing_jail: 'libioc.Jail.JailGenerator',
+        host: 'libioc.Host.Host',
+        logger: 'libioc.Logger.Logger',
+        zfs: libzfs.ZFS
+    ) -> None:
+
+        content = "{"
+
+        with open(existing_jail.config_json.file, "w", encoding="UTF-8") as f:
+            f.write(content)
+
+        with pytest.raises(libioc.errors.JailConfigError):
+            jail = libioc.Jail.Jail(
+                existing_jail.name,
+                host=host,
+                logger=logger,
+                zfs=zfs
+            )

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -154,13 +154,8 @@ class TestUserDefaultConfig(object):
         root_dataset: libzfs.ZFSDataset
     ) -> typing.IO[str]:
         defaults_config_file = f"{root_dataset.mountpoint}/defaults.json"
-        f = open(defaults_config_file, "w", encoding="UTF-8")
-        yield f
-
-        with open(defaults_config_file, "r") as x:
-            print(x.read())
-
-        f.close()
+        with open(defaults_config_file, "w", encoding="UTF-8") as f:
+            yield f
         os.remove(defaults_config_file)
 
     @pytest.fixture(scope="function")


### PR DESCRIPTION
By default reading invalid jail config causes an InvalidJailConfigValue exception, but for the ability to manipulate existing jails with such issues, it must be possible to skip invalid config properties/values.