### PR TITLE
Update deprecated JailLaunch event when installing packages

### DIFF
--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -245,7 +245,7 @@ class Pkg:
                     event_scope=packageInstallEvent.scope
                 )
                 for event in jail_exec_events:
-                    if isinstance(event, libioc.events.JailLaunch) is True:
+                    if isinstance(event, libioc.events.JailCommand) is True:
                         if event.done is True:
                             stdout = event.stdout.strip("\r\n")
                     yield event

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -55,8 +55,8 @@ class Pkg:
         host: typing.Optional['libioc.Host.Host']=None,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        self.zfs = libioc.helpers_object.init_zfs(self, zfs)
         self.logger = libioc.helpers_object.init_logger(self, logger)
+        self.zfs = libioc.helpers_object.init_zfs(self, zfs)
         self.host = libioc.helpers_object.init_host(self, host)
         self.__pkg_directory_mounted = False
 

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2017-2019, Stefan Grönke
-# Copyright (c) 2014-2018, iocage
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -44,10 +43,10 @@ _PkgConfDataType = typing.Union[
 
 
 class Pkg:
-    """iocage pkg management utility."""
+    """ioc pkg management utility."""
 
     _dataset: libzfs.ZFSDataset
-    package_source_directory: str = "/.iocage-pkg"
+    package_source_directory: str = "/.ioc-pkg"
     __pkg_directory_mounted: bool
 
     def __init__(
@@ -222,13 +221,13 @@ class Pkg:
                     "/usr/sbin/pkg",
                     "update",
                     "--force",
-                    "--repository", "libiocage"
+                    "--repository", "libioc"
                 ]),
                 " ".join([
                     "/usr/sbin/pkg",
                     "install",
                     "--yes",
-                    "--repository", "libiocage",
+                    "--repository", "libioc",
                     " ".join(_packages)
                 ])
             ] + postinstall)
@@ -341,13 +340,13 @@ class Pkg:
         return _packages
 
     def _get_repo_name(self, release_major_version: int) -> str:
-        return f"iocage-release-{release_major_version}"
+        return f"ioc-release-{release_major_version}"
 
     def _config_jail_repo(self, jail: 'libioc.Jail.JailGenerator') -> None:
         jail_directory = "/usr/local/etc/pkg/repos"
         host_directory = f"{jail.root_path}/{jail_directory}"
         self._update_repo_conf(
-            repo_name="libiocage",
+            repo_name="libioc",
             url=f"file://{self.package_source_directory}",
             directory=host_directory,
             signature_type="none"

--- a/tests/test_Pkg.py
+++ b/tests/test_Pkg.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the Pkg Jail module."""
+import typing
+import pytest
+import os
+import os.path
+
+import libzfs
+
+import libioc.Pkg
+
+
+class TestPkg(object):
+
+	@pytest.fixture(scope="function")
+	def pkg(
+		self,
+		host: 'libioc.Host.HostGenerator',
+		logger: 'libioc.Logger.LoggerGenerator',
+		zfs: 'libioc.ZFS.ZFS'
+	) -> libioc.Pkg.Pkg:
+		return libioc.Pkg.Pkg(
+			host=host,
+			logger=logger,
+			zfs=zfs
+		)
+
+	def test_can_mirror_packages(
+		self,
+		pkg: libioc.Pkg.Pkg,
+		release: 'libioc.Release.ReleaseGenerator',
+		root_dataset: libzfs.ZFSDataset
+	) -> None:
+
+		major_version = int(release.version_number)
+		local_pkg_dir = f"{root_dataset.mountpoint}/pkg/{major_version}"
+
+		list(pkg.fetch(
+			["sl", "git-lite"],
+			release=release
+		))
+
+		assert os.path.exists(local_pkg_dir)
+		assert os.path.isdir(local_pkg_dir)
+		assert os.path.exists(
+			f"{local_pkg_dir}/repos/ioc-release-{major_version}.conf"
+		)
+
+		cache_dir_index = os.listdir(f"{local_pkg_dir}/cache")
+		assert any([x.startswith("sl") for x in cache_dir_index])
+		assert any([x.startswith("git-lite") for x in cache_dir_index])
+
+	def test_can_install_packages_to_stopped_jail(
+		self,
+		pkg: libioc.Pkg.Pkg,
+		release: 'libioc.Release.ReleaseGenerator',
+		existing_jail: 'libioc.Jail.Jail'
+	) -> None:
+		packages = ["sl"]
+		list(pkg.fetch(packages, release=release))
+
+		jail_command_event = None
+		for event in pkg.install(packages=packages, jail=existing_jail):
+			if isinstance(event, libioc.events.JailCommand) and event.done:
+				jail_command_event = event
+		assert jail_command_event is not None
+		assert os.path.exists(f"{existing_jail.root_path}/usr/local/bin/sl")


### PR DESCRIPTION
The JailLaunch event was deprecated in favor of more fine grained events. The one that pkg installation should use is the JailCommand event.

blocked by #695