### PR TITLE
pass jailStartEvent.scope to child events

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -521,9 +521,9 @@ class JailGenerator(JailResource):
 
         # Setup Network
         if self.config["vnet"]:
-            yield from self._start_vimage_network()
-            yield from self._configure_localhost_commands()
-            yield from self._configure_routes_commands()
+            yield from self._start_vimage_network(jailStartEvent.scope)
+            yield from self._configure_localhost_commands(jailStartEvent.scope)
+            yield from self._configure_routes_commands(jailStartEvent.scope)
             if self.host.ipfw_enabled is True:
                 self.logger.verbose(
                     f"Disabling IPFW in the jail {self.full_name}"
@@ -532,7 +532,9 @@ class JailGenerator(JailResource):
 
         # Attach shared ZFS datasets
         if self.config["jail_zfs"] is True:
-            yield from self._zfs_share_storage.mount_zfs_shares()
+            yield from self._zfs_share_storage.mount_zfs_shares(
+                event_scope=jailStartEvent.scope
+            )
 
         if quick is False:
             unknown_config_parameters = list(


### PR DESCRIPTION
- fix nesting of multiple events on start of a Jail

### before
```console
$ ioc start myjail
[+] JailStart@myjail: OK [0.325s]
  [+] JailDependantsStart@myjail: OK [0.008s]
    [+] JailDependantStart@otherjail: already running [0.0s]
  [+] JailResolverConfig@myjail: OK [0.001s]
  [+] JailResourceLimitAction@myjail: SKIPPED [0.003s]
  [+] JailHookPrestart@myjail: SKIPPED [0.0s]
  [+] BasejailStorageConfig@myjail: OK [0.018s]
  [+] MountFstab@myjail: OK [0.001s]
  [+] JailAttach@myjail: OK [0.01s]
  [+] JailHookCreated@myjail: SKIPPED [0.0s]
  [+] MountDevFS@myjail: OK [0.001s]
[+] VnetSetup@myjail: OK [0.065s]
  [+] VnetInterfaceConfig@myjail: OK [0.065s]
[+] VnetSetupLocalhost@myjail: OK [0.013s]
[+] VnetSetRoutes@myjail: OK [0.014s]
  [+] JailHookStart@myjail: OK [0.112s]
  [+] JailHookPoststart@myjail: SKIPPED [0.0s]
```

### after
```console
$ ioc start myjail
[+] JailStart@myjail: OK [0.327s]
  [+] JailDependantsStart@myjail: OK [0.008s]
    [+] JailDependantStart@otherjail: already running [0.0s]
  [+] JailResolverConfig@myjail: OK [0.001s]
  [+] JailResourceLimitAction@myjail: SKIPPED [0.003s]
  [+] JailHookPrestart@myjail: SKIPPED [0.0s]
  [+] BasejailStorageConfig@myjail: OK [0.018s]
  [+] MountFstab@myjail: OK [0.001s]
  [+] JailAttach@myjail: OK [0.01s]
  [+] JailHookCreated@myjail: SKIPPED [0.0s]
  [+] MountDevFS@myjail: OK [0.001s]
  [+] VnetSetup@myjail: OK [0.066s]
    [+] VnetInterfaceConfig@myjail: OK [0.065s]
  [+] VnetSetupLocalhost@myjail: OK [0.013s]
  [+] VnetSetRoutes@myjail: OK [0.014s]
  [+] JailHookStart@myjail: OK [0.112s]
  [+] JailHookPoststart@myjail: SKIPPED [0.0s]
```