### PR TITLE
fix usage of multiple resource limits

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1830,7 +1830,7 @@ class JailGenerator(JailResource):
 
     @property
     def __resource_limits_enabled(self) -> bool:
-        return (self.config["rlimits"] is False) is False
+        return (self.config["rlimits"] is True)
 
     def __clear_resource_limits(
         self,

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1825,7 +1825,6 @@ class JailGenerator(JailResource):
 
         if skipped is True:
             yield event.skip()
-            return
         else:
             yield event.end()
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1858,7 +1858,7 @@ class JailGenerator(JailResource):
                 "2>&1"
             ]),
             ignore_error=True,
-            shell=True
+            shell=True  # nosec: B604
         )
 
         if (returncode > 0) and ("No such process" not in stdout):

--- a/tests/test_ResourceLimits.py
+++ b/tests/test_ResourceLimits.py
@@ -26,7 +26,20 @@ import typing
 import pytest
 import subprocess
 
+import freebsd_sysctl
 
+try:
+    rctl_supported = (freebsd_sysctl.Sysctl("kern.features.rctl").value == 1)
+    rctl_enabled = (freebsd_sysctl.Sysctl("kern.racct.enable").value == 1)
+    rctl_supported = (rctl_supported and rctl_enabled) is True
+except Exception:
+    rctl_supported = False
+
+
+@pytest.mark.skipif(
+    (rctl_supported is False),
+    reason="Resource Limits disabled (kern.features.rctl=0)."
+)
 class TestResourceLimits(object):
     """Run Resource Limit tests."""
 

--- a/tests/test_ResourceLimits.py
+++ b/tests/test_ResourceLimits.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2017-2019, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for Jail Resource Limits."""
+import typing
+import pytest
+import subprocess
+
+
+class TestResourceLimits(object):
+    """Run Resource Limit tests."""
+
+    @staticmethod
+    def __mib_to_bytes(value: int) -> int:
+        return value * 1024 * 1024
+
+    def test_limits_are_applied_to_jails_on_start(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+
+        vmemoryuse_bytes = self.__mib_to_bytes(1024)
+        memoryuse_bytes = self.__mib_to_bytes(512)
+
+        existing_jail.config["pcpu"] = 20
+        existing_jail.config["vmemoryuse"] = "1024M"
+        existing_jail.config["memoryuse"] = "512M"
+        existing_jail.save()
+
+        existing_jail.start()
+        identifier = existing_jail.identifier
+
+        lines = subprocess.check_output(
+            [f"/usr/bin/rctl | grep {identifier}"],
+            shell=True
+        ).decode("utf-8").strip().split("\n")
+
+        assert f"jail:{identifier}:pcpu:deny=20" in lines
+        assert f"jail:{identifier}:vmemoryuse:deny={vmemoryuse_bytes}" in lines
+        assert f"jail:{identifier}:memoryuse:deny={memoryuse_bytes}" in lines
+        assert len(lines) == 3
+
+        lines = subprocess.check_output(
+            [f"/usr/bin/rctl", "-u", f"jail:{identifier}"]
+        ).decode("utf-8").strip().split("\n")
+
+    def test_limits_are_removed_when_a_jail_is_stopped(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+
+        existing_jail.config["pcpu"] = 20
+        existing_jail.config["vmemoryuse"] = "1024M"
+        existing_jail.config["memoryuse"] = "512M"
+        existing_jail.save()
+
+        existing_jail.start()
+        existing_jail.stop()
+
+        # rctl timing issue
+        import time
+        time.sleep(1)
+
+        stdout = subprocess.check_output(
+            [f"/usr/bin/rctl | grep {existing_jail.identifier} | 2>&1"],
+            shell=True
+        ).decode("utf-8").strip()
+
+        assert len(stdout) == 0


### PR DESCRIPTION
fixes #699

- call /usr/bin/rctl for each resource limit individually

### Future Work
- Replace rctl command forks with calls to sys/rctl.h