### PR TITLE
JailGenerator.getstring returns empty string for unknown user properties

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -850,7 +850,9 @@ class BaseConfig(dict):
             return True
         return (fragments[0] in self["interfaces"].keys()) is True
 
-    def _is_user_property(self, key: str) -> bool:
+    @staticmethod
+    def is_user_property(key: str) -> bool:
+        """Return whether the given key belongs to a custom user property."""
         return (key == "user") or (key.startswith("user.") is True)
 
     def _is_known_property(self, key: str, explicit: bool) -> bool:
@@ -865,7 +867,7 @@ class BaseConfig(dict):
             return True  # key is special property
         if self._key_is_mac_config(key, explicit=explicit) is True:
             return True  # nic mac config property
-        if self._is_user_property(key) is True:
+        if self.is_user_property(key) is True:
             return True  # user.* property
         return False
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -39,6 +39,7 @@ import libioc.helpers
 import libioc.helpers_object
 import libioc.DevfsRules
 import libioc.Host
+import libioc.Config.Jail.BaseConfig
 import libioc.Config.Jail.JailConfig
 import libioc.Network
 import libioc.Release
@@ -222,6 +223,24 @@ class JailResource(
             pass
 
         return self.jail.config[key]
+
+    def getstring(self, key: str) -> str:
+        """
+        Get any resource property as string or '-'.
+
+        Returns the string value, or an empty string in case of an unknown user
+        config property.
+
+        Args:
+            key (string):
+                Name of the jail property to return
+        """
+        try:
+            return str(super().getstring(key))
+        except libioc.errors.UnknownConfigProperty:
+            if libioc.Config.Jail.BaseConfig.BaseConfig.is_user_property(key):
+                return ""
+            raise
 
 
 class JailGenerator(JailResource):

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -198,3 +198,12 @@ class TestNullFSBasejail(object):
         ).decode("utf-8")
         for basedir in basedirs:
             assert f"{root_path}/{basedir}" not in stdout
+
+    def test_getstring_returns_empty_string_for_unknown_user_properties(
+        self,
+        new_jail: 'libioc.Jail.Jail',
+    ) -> None:
+        """Test if getstring for an unknown user property is empty."""
+        assert new_jail.getstring("user.unknown_propery") == ""
+        with pytest.raises(libioc.errors.UnknownConfigProperty):
+            new_jail.getstring("unknown_property")


### PR DESCRIPTION
addresses #707

- return an empty string when accessing unknown config properties in the user.* namespace via JailGenerator.getstring()