### PR TITLE
support output of firewall rules

### DIFF
--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -82,6 +82,16 @@ class Firewall:
             logger=self.logger
         )
 
+    def rules(
+        self
+    ) -> str:
+        """Output lists of firewall rule."""
+        command = [
+            self.IPFW_COMMAND,
+            "-a", "list"
+        ]
+        self._exec(command)
+
     def delete_rule(
         self,
         rule_number: typing.Union[int, str],
@@ -130,7 +140,7 @@ class Firewall:
         ignore_error: bool=False
     ) -> None:
         try:
-            libioc.helpers.exec(command, ignore_error=ignore_error)
+            return libioc.helpers.exec(command, ignore_error=ignore_error)
         except libioc.errors.CommandFailure:
             raise libioc.errors.FirewallCommandFailure(
                 logger=self.logger

--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -90,7 +90,7 @@ class Firewall:
             self.IPFW_COMMAND,
             "-a", "list"
         ]
-        self._exec(command)
+        return self._exec_list(command)
 
     def delete_rule(
         self,
@@ -134,13 +134,25 @@ class Firewall:
         _rule_number = int(rule_number)
         return str(_rule_number + self.IPFW_RULE_OFFSET)
 
+    def _exec_list(
+        self,
+        command: typing.List[str],
+        ignore_error: bool=False
+    ) -> str:
+        try:
+            return str(libioc.helpers.exec(command, ignore_error=ignore_error))
+        except libioc.errors.CommandFailure:
+            raise libioc.errors.FirewallCommandFailure(
+                logger=self.logger
+            )
+
     def _exec(
         self,
         command: typing.List[str],
         ignore_error: bool=False
     ) -> None:
         try:
-            return libioc.helpers.exec(command, ignore_error=ignore_error)
+            libioc.helpers.exec(command, ignore_error=ignore_error)
         except libioc.errors.CommandFailure:
             raise libioc.errors.FirewallCommandFailure(
                 logger=self.logger

--- a/libioc/Firewall.py
+++ b/libioc/Firewall.py
@@ -90,7 +90,7 @@ class Firewall:
             self.IPFW_COMMAND,
             "-a", "list"
         ]
-        return self._exec_list(command)
+        return str(self._exec(command))
 
     def delete_rule(
         self,
@@ -134,25 +134,13 @@ class Firewall:
         _rule_number = int(rule_number)
         return str(_rule_number + self.IPFW_RULE_OFFSET)
 
-    def _exec_list(
+    def _exec(
         self,
         command: typing.List[str],
         ignore_error: bool=False
     ) -> str:
         try:
             return str(libioc.helpers.exec(command, ignore_error=ignore_error))
-        except libioc.errors.CommandFailure:
-            raise libioc.errors.FirewallCommandFailure(
-                logger=self.logger
-            )
-
-    def _exec(
-        self,
-        command: typing.List[str],
-        ignore_error: bool=False
-    ) -> None:
-        try:
-            libioc.helpers.exec(command, ignore_error=ignore_error)
         except libioc.errors.CommandFailure:
             raise libioc.errors.FirewallCommandFailure(
                 logger=self.logger


### PR DESCRIPTION
Hi all.

A firewall rules add or delete via libioc, that result wants output.
To implement it, I did commit of Firewall.rules method.
It is very simply, Because, I want review(Also, it's need or unnecessary)
Regards,

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/bsdci/libioc/blob/master/CONTRIBUTING.md)
