### PR TITLE
omit duplicate unknown jail property warnings

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -641,10 +641,15 @@ class BaseConfig(dict):
     ) -> None:
         """Set a configuration value."""
         if self._is_known_property(key, explicit=explicit) is False:
+            if "jail" in dir(self):
+                _jail = self.jail  # noqa: T484
+            else:
+                _jail = None
             err = libioc.errors.UnknownConfigProperty(
                 key=key,
                 logger=self.logger,
-                level=("warn" if skip_on_error else "error")
+                level=("warn" if skip_on_error else "error"),
+                jail=_jail
             )
             if skip_on_error is False:
                 raise err

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -737,7 +737,9 @@ class BaseConfig(dict):
         existed_before = (key in self.keys()) is True
 
         try:
-            if isinstance(
+            if existed_before is False:
+                hash_before = False
+            elif isinstance(
                 self,
                 libioc.Config.Jail.Defaults.JailConfigDefaults
             ) is True:

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -536,12 +536,22 @@ class UnknownConfigProperty(IocException, KeyError):
         self,
         key: str,
         logger: typing.Optional['libioc.Logger.Logger']=None,
-        level: str="error"
+        level: str="error",
+        jail: typing.Optional['libioc.Jail.JailGenerator']=None
     ) -> None:
-        msg = (
-            f"The config property '{key}' is unknown"
+        if jail is None:
+            msg = f"The config property '{key}' is unknown"
+        else:
+            msg = (
+                f"The config property '{key}' of jail '{jail.name}' is unknown"
+            )
+        self.jail = jail
+        IocException.__init__(
+            self,
+            message=msg,
+            logger=logger,
+            level=level
         )
-        IocException.__init__(self, message=msg, logger=logger, level=level)
 
 
 # Backup


### PR DESCRIPTION
- do not generate a hash of unset jail config properties

### Bugs
- omit duplicate warnings when listing jails with unknown properties

### Enhancements
- warnings about unknown jail config properties reference their jail name