### PR TITLE
improve error messages on invalid jail names

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -226,13 +226,9 @@ class BaseConfig(dict):
         disallowed_characters_pattern = "([^A-Za-z0-9_\\-]|\\^)"
         invalid_characters = re.findall(disallowed_characters_pattern, name)
         if len(invalid_characters) > 0:
-            msg = (
-                f"Invalid character in name: "
-                " ".join(invalid_characters)
-            )
-            self.logger.error(msg)
             raise libioc.errors.InvalidJailName(
-                name="INVALID",
+                name=name,
+                invalid_characters=invalid_characters,
                 logger=self.logger
             )
 

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -385,12 +385,15 @@ class InvalidJailName(JailConfigError):
     def __init__(
         self,
         name: str,
+        invalid_characters: typing.Optional[typing.List[str]]=None,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
         msg = (
             f"Invalid jail name '{name}': "
-            "Names have to begin and end with an alphanumeric character"
+            "Names may only contain alphanumeric characters and dash"
         )
+        if invalid_characters is not None:
+            msg += ", but got " + str("".join(invalid_characters) + "")
         super().__init__(message=msg, logger=logger)
 
 


### PR DESCRIPTION
When a jail has an invalid name, the error message now contains hints about what is wrong with a jails name.