### PR TITLE
rename JailShutdown to JailStop event in puppet provisioner

### DIFF
--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -252,7 +252,7 @@ def provision(
             raise e
 
         if started is True:
-            jailStopEvent = libioc.events.JailShutdown(
+            jailStopEvent = libioc.events.JailStop(
                 jail=self.jail,
                 scope=jailProvisioningEvent.scope
             )


### PR DESCRIPTION
The JailShutdown event was renamed to JailStop. This PR adapts to this breaking change.