### PR TITLE
Unmount puppet provisioner environment

### DIFF
--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -327,7 +327,7 @@ class Fstab(collections.MutableSequence):
         replace: bool=False,
         auto_create_destination: bool=False,
         auto_mount_jail: bool=True
-    ) -> None:
+    ) -> typing.Union[FstabLine, FstabCommentLine, FstabAutoPlaceholderLine]:
         """
         Append a new line to the fstab file.
 
@@ -343,7 +343,7 @@ class Fstab(collections.MutableSequence):
             "comment": comment
         })
 
-        self.add_line(
+        return self.add_line(
             line=line,
             replace=replace,
             auto_create_destination=auto_create_destination,
@@ -361,14 +361,12 @@ class Fstab(collections.MutableSequence):
         replace: bool=False,
         auto_create_destination: bool=False,
         auto_mount_jail: bool=True
-    ) -> None:
+    ) -> typing.Union[FstabLine, FstabCommentLine, FstabAutoPlaceholderLine]:
         """
         Directly append a FstabLine type.
 
         Use save() to write changes to the fstab file.
         """
-        FstabCommentLine
-        FstabAutoPlaceholderLine
         if any((
             isinstance(line, FstabLine),
             isinstance(line, FstabCommentLine),
@@ -380,6 +378,7 @@ class Fstab(collections.MutableSequence):
             )
 
         self._lines.append(line)
+        return line
 
     def index(
         self,
@@ -648,7 +647,7 @@ class JailFstab(Fstab):
         replace: bool=False,
         auto_create_destination: bool=False,
         auto_mount_jail: bool=True
-    ) -> None:
+    ) -> typing.Union[FstabLine, FstabCommentLine, FstabAutoPlaceholderLine]:
         """
         Directly append a FstabLine type.
 
@@ -674,7 +673,7 @@ class JailFstab(Fstab):
                 self.logger.verbose(
                     f"Skipping existing fstab line: {line}"
                 )
-                return
+                return line
             else:
                 raise libioc.errors.FstabDestinationExists(
                     mountpoint=destination,
@@ -727,6 +726,7 @@ class JailFstab(Fstab):
                 )
 
         self._lines.append(line)
+        return line
 
     def update_release(
         self,

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -63,7 +63,7 @@ class JailResource(
     """Resource that represents a jail."""
 
     _jail: 'JailGenerator'
-    _fstab: 'libioc.Config.Jail.File.Fstab.Fstab'
+    _fstab: 'libioc.Config.Jail.File.Fstab.JailFstab'
     host: 'libioc.Host.HostGenerator'
     root_datasets_name: typing.Optional[str]
 
@@ -77,7 +77,7 @@ class JailResource(
         logger: typing.Optional['libioc.Logger.Logger']=None,
         zfs: typing.Optional[libioc.ZFS.ZFS]=None,
         host: typing.Optional['libioc.Host.HostGenerator']=None,
-        fstab: typing.Optional['libioc.Config.Jail.File.Fstab.Fstab']=None,
+        fstab: typing.Optional['libioc.Config.Jail.File.Fstab.JailFstab']=None,
         root_datasets_name: typing.Optional[str]=None,
     ) -> None:
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -260,7 +260,6 @@ def provision(
             yield from self.jail.stop(event_scope=jailStopEvent.scope)
             yield jailStopEvent.end()
     finally:
-        # in case anything fails the fstab mount needs to be removed
-        del self.jail.fstab[-1]
+        del self.jail.fstab[self.jail.fstab.index(fstab_line)]
 
     yield jailProvisioningEvent.end()

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -165,13 +165,7 @@ def provision(
 
     if self.jail.stopped is True:
         started = True
-        jailStartEvent = libioc.events.JailStart(
-            jail=self.jail,
-            scope=jailProvisioningEvent.scope
-        )
-        yield jailStartEvent.begin()
-        yield from self.jail.start(event_scope=jailStartEvent.scope)
-        yield jailStartEvent.end()
+        yield from self.jail.start(event_scope=_scope)
     else:
         started = False
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -178,13 +178,13 @@ def provision(
     yield from pkg.install(
         jail=self.jail,
         packages=list(pluginDefinition.pkgs),
-        event_scope=jailProvisioningEvent.scope
+        event_scope=_scope
     )
 
     puppet_env_dir = "/usr/local/etc/puppet/environments"
 
     self.jail.logger.spam("Mounting puppet environment")
-    self.jail.fstab.new_line(
+    fstab_line = self.jail.fstab.new_line(
         source=mount_source,
         destination=puppet_env_dir,
         options=mode,
@@ -196,7 +196,7 @@ def provision(
         if self.source.remote is True:
 
             r10kDeployEvent = R10kDeployEvent(
-                scope=jailProvisioningEvent.scope,
+                scope=_scope,
                 jail=self.jail
             )
 
@@ -227,7 +227,7 @@ def provision(
             yield r10kDeployEvent.end()
 
         puppetApplyEvent = PuppetApplyEvent(
-            scope=jailProvisioningEvent.scope,
+            scope=_scope,
             jail=self.jail
         )
         yield puppetApplyEvent.begin()
@@ -248,7 +248,7 @@ def provision(
         if started is True:
             jailStopEvent = libioc.events.JailStop(
                 jail=self.jail,
-                scope=jailProvisioningEvent.scope
+                scope=_scope
             )
             yield jailStopEvent.begin()
             yield from self.jail.stop(event_scope=jailStopEvent.scope)


### PR DESCRIPTION
### Enhancements
- Fstab new_line() and add_line() finally return the added line

## Bugs
- Correct puppet provisioner event stack
- Unmount puppet provisioner environment after stopping the jail