### PR TITLE
Mount fdescfs on jail start when mount_fdescfs is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install-deps-dev: install-deps
 install-dev: install-deps-dev install-python-requirements-dev
 	$(PYTHON) -m pip install -e .
 install-travis:
-	python3.6 -m pip install flake8-mutable flake8-docstrings flake8-builtins flake8-mypy bandit bandit-high-entropy-string
+	python3.6 -m pip install -IU flake8-mutable flake8-docstrings flake8-builtins flake8-mypy bandit==1.5.1 bandit-high-entropy-string
 uninstall:
 	$(PYTHON) -m pip uninstall -y ioc
 	@if [ -f /usr/local/etc/rc.d/ioc ]; then \

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -621,7 +621,7 @@ class BaseConfig(dict):
     def unknown_config_parameters(self) -> typing.Iterator[str]:
         """Yield unknown config parameters already stored in the config."""
         for key in self.data.keys():
-            if self._is_known_property(key, explicit=True) is False:
+            if self.is_known_property(key, explicit=True) is False:
                 yield key
 
     def __delitem__(self, key: str) -> None:
@@ -636,7 +636,7 @@ class BaseConfig(dict):
         explicit: bool=True
     ) -> None:
         """Set a configuration value."""
-        if self._is_known_property(key, explicit=explicit) is False:
+        if self.is_known_property(key, explicit=explicit) is False:
             if "jail" in dir(self):
                 _jail = self.jail  # noqa: T484
             else:
@@ -865,7 +865,7 @@ class BaseConfig(dict):
         """Return whether the given key belongs to a custom user property."""
         return (key == "user") or (key.startswith("user.") is True)
 
-    def _is_known_property(self, key: str, explicit: bool) -> bool:
+    def is_known_property(self, key: str, explicit: bool) -> bool:
         """Return True when the key is a known config property."""
         if self._is_known_jail_param(key):
             return True
@@ -898,7 +898,7 @@ class BaseConfig(dict):
         key: str,
         explicit: bool=True
     ) -> None:
-        if self._is_known_property(key, explicit=explicit) is False:
+        if self.is_known_property(key, explicit=explicit) is False:
             raise libioc.errors.UnknownConfigProperty(
                 key=key,
                 logger=self.logger

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -873,6 +873,8 @@ class BaseConfig(dict):
             return True  # key is default
         if f"_set_{key}" in dict.__dir__(self):
             return True  # key is setter
+        if f"_get_{key}" in dict.__dir__(self):
+            return True  # key is getter
         if key in libioc.Config.Jail.Properties.properties:
             return True  # key is special property
         if self._key_is_mac_config(key, explicit=explicit) is True:

--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -357,6 +357,37 @@ class BaseConfig(dict):
 
         return self.__unique_list(tags)
 
+    @property
+    def __has_mounts_enabled(self) -> bool:
+        prefix = "allow_mount_"
+        return any((self[x] == 1) for x in self.keys() if x.startswith(prefix))
+
+    def _get_enforce_statfs(self) -> int:
+        key = "enforce_statfs"
+        if key in self.data.keys():
+            return int(self.data[key])
+
+        if self.__has_mounts_enabled:
+            self.logger.verbose(
+                "setting enforce_statfs=1 to support allowed mounts"
+            )
+            return 1
+
+        raise KeyError(f"{key} unconfigured")
+
+    def _get_allow_mount(self) -> int:
+        key = "allow_mount"
+        if key in self.data.keys():
+            return int(self.data[key])
+
+        if self.__has_mounts_enabled:
+            self.logger.verbose(
+                "inheriting allow_mount=1 from allowed mounts"
+            )
+            return 1
+
+        raise KeyError(f"{key} unconfigured")
+
     def __unique_list(self, seq: typing.List[str]) -> typing.List[str]:
         seen: typing.Set[str] = set()
         seen_add = seen.add

--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -633,7 +633,7 @@ class JailFstab(Fstab):
             return self.file
         else:
             path = f"{self.jail.dataset.mountpoint}/{self.file}"
-            self.jail._require_relative_path(path)
+            self.jail.require_relative_path(path)
             return path
 
     def add_line(
@@ -692,7 +692,7 @@ class JailFstab(Fstab):
                     self.jail.root_path,
                     line["destination"].strip("/")
                 ]))
-                self.jail._require_relative_path(_destination)
+                self.jail.require_relative_path(_destination)
                 line["destination"] = _destination
 
             libioc.helpers.require_no_symlink(str(line["destination"]))
@@ -707,7 +707,7 @@ class JailFstab(Fstab):
 
             if (auto_mount_jail and self.jail.running) is True:
                 destination = line["destination"]
-                self.jail._require_relative_path(destination)
+                self.jail.require_relative_path(destination)
                 self.logger.verbose(
                     f"auto-mount {destination}"
                 )

--- a/libioc/Config/Jail/File/__init__.py
+++ b/libioc/Config/Jail/File/__init__.py
@@ -210,5 +210,5 @@ class ResourceConfigFile(ConfigFile):
     def path(self) -> str:
         """Absolute path to the file."""
         path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
-        self.resource._require_relative_path(path)
+        self.resource.require_relative_path(path)
         return os.path.abspath(path)

--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -80,6 +80,35 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
     def _get_legacy(self) -> bool:
         return self.legacy
 
+    def _get_mount_fdescfs(self) -> bool:
+        return (self.data["mount_fdescfs"] == "1") is True
+
+    def _set_mount_fdescfs(self, value: typing.Union[str, int, bool]) -> None:
+
+        error_reason: typing.Optional[str] = None
+        if isinstance(value, bool) is True:
+            enabled = (value is True)
+        else:
+            try:
+                str_value = str(int(value))
+            except ValueError:
+                error_reason = "invalid input type (expected int or str)"
+
+            if (str_value != "0") and (str_value != "1"):
+                error_reason = f"Boolean input expected, but got {str_value}"
+
+            enabled = (str_value == "1")
+
+        if error_reason is not None:
+            raise libioc.errors.InvalidJailConfigValue(
+                jail=self.jail,
+                property_name="mount_fdescfs",
+                reason=error_reason,
+                logger=self.logger
+            )
+
+        self.data["mount_fdescfs"] = ("1" if enabled else "0")
+
     def __getitem__(self, key: str) -> typing.Any:
         """Get the value of a configuration argument or its default."""
         try:

--- a/libioc/Config/Jail/JailConfig.py
+++ b/libioc/Config/Jail/JailConfig.py
@@ -80,10 +80,26 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
     def _get_legacy(self) -> bool:
         return self.legacy
 
-    def _get_mount_fdescfs(self) -> bool:
-        return (self.data["mount_fdescfs"] == "1") is True
+    def _get_mount_fdescfs(self) -> int:
+        return self.__get_mount(key="mount_fdescfs")
 
     def _set_mount_fdescfs(self, value: typing.Union[str, int, bool]) -> None:
+        self.__set_mount(key="mount_fdescfs", value=value)
+
+    def _get_mount_devfs(self) -> int:
+        return self.__get_mount(key="mount_devfs")
+
+    def _set_mount_devfs(self, value: typing.Union[str, int, bool]) -> None:
+        self.__set_mount(key="mount_devfs", value=value)
+
+    def __get_mount(self, key: str) -> int:
+        return 1 * ((int(self.data[key]) == 1) is True)
+
+    def __set_mount(
+        self,
+        key: str,
+        value: typing.Union[str, int, bool]
+    ) -> None:
 
         error_reason: typing.Optional[str] = None
         if isinstance(value, bool) is True:
@@ -92,7 +108,7 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
             try:
                 str_value = str(int(value))
             except ValueError:
-                error_reason = "invalid input type (expected int or str)"
+                error_reason = "invalid input type (expected int, str or bool)"
 
             if (str_value != "0") and (str_value != "1"):
                 error_reason = f"Boolean input expected, but got {str_value}"
@@ -107,7 +123,7 @@ class JailConfig(libioc.Config.Jail.BaseConfig.BaseConfig):
                 logger=self.logger
             )
 
-        self.data["mount_fdescfs"] = ("1" if enabled else "0")
+        self.data[key] = ("1" if enabled else "0")
 
     def __getitem__(self, key: str) -> typing.Any:
         """Get the value of a configuration argument or its default."""

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1609,7 +1609,7 @@ class JailGenerator(JailResource):
                     value += [x.ip for x in addresses]
             else:
                 config_property_name = sysctl.iocage_name
-                if self.config._is_known_property(
+                if self.config.is_known_property(
                     config_property_name,
                     explicit=False
                 ) is True:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -649,16 +649,7 @@ class JailGenerator(JailResource):
         )
         yield _event.begin()
 
-        iocage_property_name = f"allow_mount_{filesystem}"
-        if self.config[iocage_property_name] is False:
-            raise libioc.errors.InvalidJailConfigValue(
-                property_name=iocage_property_name,
-                jail=self,
-                logger=self.logger,
-                reason="fdescfs is not allowed to be mounted"
-            )
-
-        if self.config[f"mount_{filesystem}"] is False:
+        if int(self.config[f"mount_{filesystem}"]) == 0:
             yield _event.skip("disabled")
             return
 
@@ -673,7 +664,7 @@ class JailGenerator(JailResource):
         except Exception as e:
             yield _event.fail(str(e))
             raise e
-        if os.path.isdir(_mountpoint) is None:
+        if os.path.isdir(_mountpoint) is False:
             os.makedirs(_mountpoint, mode=0o555)
 
         try:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -633,34 +633,6 @@ class JailGenerator(JailResource):
 
         yield event.end()
 
-    def __unmount_devfs(
-        self,
-        event_scope: typing.Optional['libioc.events.Scope']=None
-    ) -> typing.Generator['libioc.events.UnmountDevFS', None, None]:
-
-        event = libioc.events.UnmountDevFS(
-            jail=self,
-            scope=event_scope
-        )
-        yield event.begin()
-
-        devpath = f"{self.root_path}/dev"
-
-        if os.path.ismount(devpath) is False:
-            yield event.skip()
-            return
-        try:
-            libioc.helpers.umount(
-                mountpoint=devpath,
-                logger=self.logger,
-                frce=True
-            )
-        except Exception as e:
-            yield event.fail(e)
-            raise e
-
-        yield event.end()
-
     def __mount_fdescfs(
         self,
         event_scope: typing.Optional['libioc.events.Scope']=None
@@ -695,34 +667,6 @@ class JailGenerator(JailResource):
             libioc.helpers.mount(
                 destination=fdescfs_path,
                 fstype="fdescfs"
-            )
-        except Exception as e:
-            yield event.fail(e)
-            raise e
-
-        yield event.end()
-
-    def __unmount_devfs(
-        self,
-        event_scope: typing.Optional['libioc.events.Scope']=None
-    ) -> typing.Generator['libioc.events.UnmountFdescfs', None, None]:
-
-        event = libioc.events.UnmountFdescfs(
-            jail=self,
-            scope=event_scope
-        )
-        yield event.begin()
-
-        fdescfs_path = f"{self.root_path}/dev/fd"
-
-        if os.path.ismount(fdescfs_path) is False:
-            yield event.skip()
-            return
-        try:
-            libioc.helpers.umount(
-                mountpoint=fdescfs_path,
-                logger=self.logger,
-                frce=True
             )
         except Exception as e:
             yield event.fail(e)
@@ -1615,10 +1559,6 @@ class JailGenerator(JailResource):
         else:
             ruleset_line_position = self.host.devfs.index(devfs_ruleset)
             return self.host.devfs[ruleset_line_position].number
-
-    @staticmethod
-    def __get_launch_command(jail_args: typing.List[str]) -> typing.List[str]:
-        return ["/usr/sbin/jail", "-c"] + jail_args
 
     @property
     def _launch_params(self) -> libjail.Jiov:

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -665,7 +665,7 @@ class JailGenerator(JailResource):
 
         try:
             _mountpoint = str(f"{self.root_path}{mountpoint}")
-            self._require_relative_path(_mountpoint)
+            self.require_relative_path(_mountpoint)
             if os.path.islink(_mountpoint) or os.path.isfile(_mountpoint):
                 raise libioc.errors.InsecureJailPath(
                     path=_mountpoint,

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -31,6 +31,7 @@ import shutil
 import libzfs
 import freebsd_sysctl
 import jail as libjail
+import freebsd_sysctl.types
 
 import libioc.Types
 import libioc.errors
@@ -1577,10 +1578,6 @@ class JailGenerator(JailResource):
         value: libjail.RawIovecValue
         jail_params: typing.Dict[str, libioc.JailParams.JailParam] = {}
         for sysctl_name, sysctl in libioc.JailParams.JailParams().items():
-            if sysctl.ctl_type == freebsd_sysctl.types.NODE:
-                # skip NODE
-                continue
-
             if sysctl_name == "security.jail.param.devfs_ruleset":
                 value = int(self.devfs_ruleset)
             elif sysctl_name == "security.jail.param.path":
@@ -1624,7 +1621,7 @@ class JailGenerator(JailResource):
                 else:
                     continue
 
-            jail_params[sysctl.jail_arg_name] = value
+            jail_params[sysctl.jail_arg_name.rstrip(".")] = value
 
         jail_params["persist"] = None
         return jail_params

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1614,6 +1614,13 @@ class JailGenerator(JailResource):
                     explicit=False
                 ) is True:
                     value = config[config_property_name]
+                    if sysctl.ctl_type in (
+                        freebsd_sysctl.types.NODE,
+                        freebsd_sysctl.types.INT,
+                    ):
+                        sysctl_state_names = ["disable", "inherit", "new"]
+                        if value in sysctl_state_names:
+                            value = sysctl_state_names.index(value)
                 else:
                     continue
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1599,6 +1599,8 @@ class JailGenerator(JailResource):
                 value = []
                 for _, addresses in self.config["ip6_addr"].items():
                     value += [x.ip for x in addresses]
+            elif vnet and (sysctl_name.startswith("security.jail.param.ip")):
+                continue
             else:
                 config_property_name = sysctl.iocage_name
                 if self.config.is_known_property(

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -618,9 +618,9 @@ class JailGenerator(JailResource):
         yield from self.__mount_in_jail(
             filesystem="devfs",
             mountpoint="/dev",
-            opts=["devfs_ruleset=4"],
             event=libioc.events.MountDevFS,
-            event_scope=event_scope
+            event_scope=event_scope,
+            ruleset=self.config["devfs_ruleset"]
         )
 
     def __mount_fdescfs(
@@ -639,9 +639,8 @@ class JailGenerator(JailResource):
         filesystem: str,
         mountpoint: str,
         event: 'libioc.events.JailEvent',
-        opts: typing.List[str]=[],
         event_scope: typing.Optional['libioc.events.Scope']=None,
-
+        **iov_data: str
     ) -> typing.Generator['libioc.events.MountFdescfs', None, None]:
 
         _event = event(
@@ -681,8 +680,8 @@ class JailGenerator(JailResource):
             libioc.helpers.mount(
                 destination=_mountpoint,
                 fstype=filesystem,
-                opts=opts,
-                logger=self.logger
+                logger=self.logger,
+                ruleset=4
             )
         except Exception as e:
             yield _event.fail(str(e))

--- a/libioc/Resource.py
+++ b/libioc/Resource.py
@@ -365,10 +365,11 @@ class Resource(metaclass=abc.ABCMeta):
             "This needs to be implemented by the inheriting class"
         )
 
-    def _require_relative_path(
+    def require_relative_path(
         self,
         filepath: str,
     ) -> None:
+        """Require the resolved filepath to be relative to the jail root."""
         if self._is_path_relative(filepath) is False:
             raise libioc.errors.SecurityViolationConfigJailEscape(
                 file=filepath

--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -702,7 +702,7 @@ class FreeBSD(Updater):
     def _pre_update(self) -> None:
         """Execute before executing the update command."""
         lnk = f"{self.resource.root_path}{self._base_release_symlink_location}"
-        self.resource._require_relative_path(f"{lnk}/..")
+        self.resource.require_relative_path(f"{lnk}/..")
         if os.path.islink(lnk) is True:
             os.unlink(lnk)
         os.symlink("/", lnk)
@@ -710,7 +710,7 @@ class FreeBSD(Updater):
     def _post_update(self) -> None:
         """Execute after executing the update command."""
         lnk = f"{self.resource.root_path}{self._base_release_symlink_location}"
-        self.resource._require_relative_path(f"{lnk}/..")
+        self.resource.require_relative_path(f"{lnk}/..")
         os.unlink(lnk)
 
 

--- a/libioc/Storage/__init__.py
+++ b/libioc/Storage/__init__.py
@@ -130,6 +130,13 @@ class Storage:
         )
         yield event.begin()
 
+        try:
+            for mountpoint in system_mountpoints:
+                self.jail.require_relative_path(mountpoint)
+        except Exception as e:
+            yield event.fail(str(e))
+            raise e
+
         has_unmounted_any = False
         try:
             for mountpoint in system_mountpoints:

--- a/libioc/Storage/__init__.py
+++ b/libioc/Storage/__init__.py
@@ -137,7 +137,8 @@ class Storage:
                     continue
                 libioc.helpers.umount(
                     mountpoint=mountpoint,
-                    force=True
+                    force=True,
+                    logger=self.logger
                 )
                 has_unmounted_any = True
         except Exception:

--- a/libioc/decorators.py
+++ b/libioc/decorators.py
@@ -22,7 +22,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Collection of iocage Python decorators."""
+"""Collection of ioc Python decorators."""
 import functools
 import time
 

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -231,9 +231,12 @@ class JailLaunchFailed(JailException):
     def __init__(
         self,
         jail: 'libioc.Jail.JailGenerator',
+        reason: typing.Optional[str]=None,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
         msg = f"Launching jail {jail.full_name} failed"
+        if reason is not None:
+            msg += f": {reason}"
         JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -397,20 +397,8 @@ class MountDevFS(DevFSEvent):
     pass
 
 
-class UnmountDevFS(DevFSEvent):
-    """Unmount /dev from a jail."""
-
-    pass
-
-
 class MountFdescfs(DevFSEvent):
     """Mount /dev/fd into a jail."""
-
-    pass
-
-
-class UnmountFdescfs(DevFSEvent):
-    """Unmount /dev/fd from a jail."""
 
     pass
 

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -403,6 +403,18 @@ class UnmountDevFS(DevFSEvent):
     pass
 
 
+class MountFdescfs(DevFSEvent):
+    """Mount /dev/fd into a jail."""
+
+    pass
+
+
+class UnmountFdescfs(DevFSEvent):
+    """Unmount /dev/fd from a jail."""
+
+    pass
+
+
 class FstabEvent(JailEvent):
     """Group of events that occor on Fstab operations."""
 

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -540,13 +540,16 @@ def mount(
     source: str=None,
     fstype: str="nullfs",
     opts: typing.List[str]=[],
-    logger: typing.Optional['libioc.Logger.Logger']=None
+    logger: typing.Optional['libioc.Logger.Logger']=None,
+    **iov_data: typing.Any
 ) -> None:
     """Mount a filesystem using libc."""
     data: typing.Dict[str, typing.Optional[str]] = dict(
         fstype=fstype,
         fspath=destination
     )
+    for key, value in iov_data.items():
+        data[key] = str(value)
     if source is not None:
         data["target"] = source
     for opt in opts:

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -539,7 +539,8 @@ def mount(
     destination: str,
     source: str=None,
     fstype: str="nullfs",
-    opts: typing.List[str]=[]
+    opts: typing.List[str]=[],
+    logger: typing.Optional['libioc.Logger.Logger']=None
 ) -> None:
     """Mount a filesystem using libc."""
     data: typing.Dict[str, typing.Optional[str]] = dict(
@@ -554,7 +555,8 @@ def mount(
     if libjail.dll.nmount(jiov.pointer, len(jiov), 0) != 0:
         raise libioc.errors.MountFailed(
             mountpoint=destination,
-            reason=jiov.errmsg.value
+            reason=jiov.errmsg.value,
+            logger=logger
         )
 
 

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -558,7 +558,7 @@ def mount(
     if libjail.dll.nmount(jiov.pointer, len(jiov), 0) != 0:
         raise libioc.errors.MountFailed(
             mountpoint=destination,
-            reason=jiov.errmsg.value,
+            reason=jiov.errmsg.value.decode("UTF-8"),
             logger=logger
         )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8-docstrings
 flake8-mutable
 flake8-builtins
 flake8-mypy
-bandit
+bandit==1.5.1
 bandit-high-entropy-string
 sphinx-autodoc-typehints
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gitpython
-freebsd_sysctl==0.0.5
+freebsd_sysctl==0.0.6
 jail==0.0.8

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -92,6 +92,79 @@ class TestJail(object):
 
         assert stdout.strip().count("\n") == 0
 
+    def test_can_mount_devfs(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        """Test if a jail can be started."""
+        existing_jail.config["mount_devfs"] = True
+        existing_jail.config["mount_fdescfs"] = False
+        existing_jail.save()
+
+        existing_jail.start()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev" in stdout
+        assert "/dev/fd" not in stdout
+
+        existing_jail.stop()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev" not in stdout
+
+    def test_can_mount_fdescfs(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        """Test if a jail can be started."""
+        existing_jail.config["mount_devfs"] = False
+        existing_jail.config["mount_fdescfs"] = True
+        existing_jail.save()
+
+        existing_jail.start()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev/fd" in stdout
+        assert "/dev (" not in stdout
+
+        existing_jail.stop()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev/fd" not in stdout
+
+    def test_can_mount_devfs_and_fdescfs(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        """Test if a jail can be started."""
+        existing_jail.config["mount_devfs"] = True
+        existing_jail.config["mount_fdescfs"] = True
+        existing_jail.save()
+
+        existing_jail.start()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev (" in stdout
+        assert "/dev/fd" in stdout
+
+        existing_jail.stop()
+        stdout = subprocess.check_output(
+            [f"/sbin/mount | grep {existing_jail.root_dataset.name}"],
+            shell=True
+        ).decode("utf-8")
+        assert "/dev (" not in stdout
+        assert "/dev/fd" not in stdout
+
     def test_can_be_stopped(
         self,
         existing_jail: 'libioc.Jail.Jail'


### PR DESCRIPTION
# Security
- mount /dev and /dev/fd from within the jail
- apply security checks before unmounting system mountpoints from a jail

# Bugs
- fix mounting /dev when mount_devfs is enabled
- fix mounting /dev/fd when mount_fdescfs is enabled
- include sysvshm, sysvsem and sysvmsg jail params on start

---

`mount_descfs` is a /usr/sbin/jail argument, not a Jail parameter. Therefore it is not handled by py-jail and must be manually handled during jail start.