### PR TITLE
fix bootstrap of pkg from archive

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -872,7 +872,7 @@ class JailGenerator(JailResource):
         self.config.clone(original_config.data)
 
         try:
-            fork_exec_events = JailGenerator.start(
+            yield from JailGenerator.start(
                 self,
                 single_command=command,
                 passthru=passthru,
@@ -881,8 +881,6 @@ class JailGenerator(JailResource):
                 start_dependant_jails=start_dependant_jails,
                 env=env
             )
-            for event in fork_exec_events:
-                yield event
         finally:
             self.config = original_config
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -884,7 +884,7 @@ class JailGenerator(JailResource):
         _env = dict()
         _env_keys = env.keys()
         for key in _env_keys:
-            _env[key] = env[value]
+            _env[key] = env[key]
 
         global_env = self.env
         for key, value in global_env.items():

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -641,7 +641,8 @@ class JailGenerator(JailResource):
             yield jailStartEvent.fail(e)
             raise e
 
-        yield from _stop_jails()
+        if single_command is not None:
+            yield from _stop_jails()
         yield jailStartEvent.end()
 
     def __mount_devfs(

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -2431,9 +2431,11 @@ class Jail(JailGenerator):
             start_dependant_jails=start_dependant_jails,
             **temporary_config_override
         )
+        stdout = ""
         for event in events:
             if isinstance(
                 event,
                 libioc.events.JailCommand
             ) and event.done:
-                return str(event.stdout)
+                stdout = event.stdout
+        return stdout

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -521,19 +521,6 @@ class JailGenerator(JailResource):
             scope=jailStartEvent.scope
         )
         yield jailAttachEvent.begin()
-
-        def _stop_failed_jail(
-        ) -> typing.Generator['libioc.events.IocEvent', None, None]:
-            jails_to_stop = [self]
-            if start_dependant_jails is True:
-                jails_to_stop.extend(list(reversed(dependant_jails_started)))
-            for jail_to_stop in jails_to_stop:
-                yield from jail_to_stop.stop(
-                    force=True,
-                    event_scope=jailAttachEvent.scope
-                )
-
-        jailAttachEvent.add_rollback_step(_stop_failed_jail)
         jiov = libjail.Jiov(self._launch_params)
         jid = _dll.jail_set(jiov.pointer, len(jiov), 1)
 
@@ -554,6 +541,19 @@ class JailGenerator(JailResource):
             )
             yield jailAttachEvent.fail(error_text)
             raise error
+
+        def _stop_failed_jail(
+        ) -> typing.Generator['libioc.events.IocEvent', None, None]:
+            import pdb; pdb.set_trace()
+            jails_to_stop = [self]
+            if start_dependant_jails is True:
+                jails_to_stop.extend(list(reversed(dependant_jails_started)))
+            for jail_to_stop in jails_to_stop:
+                yield from jail_to_stop.stop(
+                    force=True,
+                    event_scope=jailAttachEvent.scope
+                )
+        jailStartEvent.add_rollback_step(_stop_failed_jail)
 
         # Created Hook
         yield from self.__run_hook(

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -641,7 +641,7 @@ class JailGenerator(JailResource):
             yield jailStartEvent.fail(e)
             raise e
 
-        _stop_jails()
+        yield from _stop_jails()
         yield jailStartEvent.end()
 
     def __mount_devfs(

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -389,13 +389,13 @@ class Pkg:
         postinstall: typing.List[str]=[]
     ) -> typing.Generator[libioc.events.PkgEvent, None, None]:
         """Mirror and install packages to a jail."""
-        yield from self.bootstrap(
-            jail=jail,
-            event_scope=event_scope
-        )
         yield from self.fetch(
             packages=packages,
             release=jail.release,
+            event_scope=event_scope
+        )
+        yield from self.bootstrap(
+            jail=jail,
             event_scope=event_scope
         )
         yield from self.install(

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -65,7 +65,7 @@ class Pkg:
         packages: typing.Union[str, typing.List[str]],
         release: 'libioc.Release.ReleaseGenerator',
         event_scope: typing.Optional['libioc.events.Scope']=None
-    ) -> typing.Generator[libioc.events.IocEvent, None, None]:
+    ) -> typing.Generator[libioc.events.PkgEvent, None, None]:
         """Fetch a bunch of packages to the local mirror."""
         _packages = self._normalize_packages(packages)
         _packages.append("pkg")
@@ -182,7 +182,7 @@ class Pkg:
         jail: 'libioc.Jail.JailGenerator',
         event_scope: typing.Optional['libioc.events.Scope']=None,
         postinstall: typing.List[str]=[]
-    ) -> typing.Generator[libioc.events.IocEvent, None, None]:
+    ) -> typing.Generator[libioc.events.PkgEvent, None, None]:
         """Install locally mirrored packages to a jail."""
         _packages = self._normalize_packages(packages)
         release_major_version = math.floor(jail.release.version_number)
@@ -262,7 +262,7 @@ class Pkg:
         packages: typing.Union[str, typing.List[str]],
         jail: 'libioc.Jail.JailGenerator',
         event_scope: typing.Optional['libioc.events.Scope']=None
-    ) -> typing.Generator[libioc.events.IocEvent, None, None]:
+    ) -> typing.Generator[libioc.events.PkgEvent, None, None]:
         """Remove installed packages from a jail."""
         _packages = self._normalize_packages(packages)
 
@@ -320,7 +320,7 @@ class Pkg:
         jail: 'libioc.Jail.JailGenerator',
         event_scope: typing.Optional['libioc.events.Scope']=None,
         postinstall: typing.List[str]=[]
-    ) -> typing.Generator[libioc.events.IocEvent, None, None]:
+    ) -> typing.Generator[libioc.events.PkgEvent, None, None]:
         """Mirror and install packages to a jail."""
         yield from self.fetch(
             packages=packages,

--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -190,15 +190,19 @@ class Pkg:
 
         dataset = self.__get_jail_release_pkg_dataset(jail)
         pkg_archive_name = self._get_latest_pkg_archive(dataset.mountpoint)
-        yield from self.__run_command(
-            jail=jail,
-            command=[
-                "/usr/sbin/pkg",
-                "add",
-                f"{self.package_source_directory}/{pkg_archive_name}"
-            ],
-            event_scope=event.scope
-        )
+        try:
+            yield from self.__run_command(
+                jail=jail,
+                command=[
+                    "/usr/sbin/pkg",
+                    "add",
+                    f"{self.package_source_directory}/{pkg_archive_name}"
+                ],
+                event_scope=event.scope
+            )
+        except Exception as e:
+            yield event.fail(e)
+            raise e
 
         yield event.end()
 

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -479,6 +479,8 @@ class JailCommand(JailHook):
     """Run command in a jail."""
 
     stdout: typing.Optional[str]
+    stderr: typing.Optional[str]
+    code: typing.Optional[int]
 
 
 class JailHookCreated(JailHook):

--- a/libioc/events.py
+++ b/libioc/events.py
@@ -1050,7 +1050,13 @@ class JailProvisioningAssetDownload(JailEvent):
 # PKG
 
 
-class PackageFetch(IocEvent):
+class PkgEvent(IocEvent):
+    """Collection of events related to Pkg."""
+
+    pass
+
+
+class PackageFetch(PkgEvent):
     """Fetch packages for offline installation."""
 
     packages: typing.List[str]
@@ -1067,7 +1073,13 @@ class PackageFetch(IocEvent):
         IocEvent.__init__(self, message=message, scope=scope)
 
 
-class PackageInstall(JailEvent):
+class BootstrapPkg(JailEvent, PkgEvent):
+    """Bootstrap pkg within a jail."""
+
+    pass
+
+
+class PackageInstall(JailEvent, PkgEvent):
     """Install packages in a jail."""
 
     def __init__(
@@ -1082,7 +1094,7 @@ class PackageInstall(JailEvent):
         JailEvent.__init__(self, jail=jail, message=message, scope=scope)
 
 
-class PackageRemove(JailEvent):
+class PackageRemove(JailEvent, PkgEvent):
     """Remove packages from a jail."""
 
     def __init__(
@@ -1097,7 +1109,7 @@ class PackageRemove(JailEvent):
         JailEvent.__init__(self, jail=jail, message=message, scope=scope)
 
 
-class PackageConfiguration(JailEvent):
+class PackageConfiguration(JailEvent, PkgEvent):
     """Install packages in a jail."""
 
     pass

--- a/tests/test_Pkg.py
+++ b/tests/test_Pkg.py
@@ -80,15 +80,11 @@ class TestPkg(object):
         existing_jail: 'libioc.Jail.Jail'
     ) -> None:
         packages = ["sl"]
-        list(pkg.fetch(packages, release=release))
-
-        jail_command_event = None
-        for event in pkg.install(packages=packages, jail=existing_jail):
-            if isinstance(event, libioc.events.JailCommand) and event.done:
-                jail_command_event = event
-        assert jail_command_event is not None
+        list(pkg.fetch_and_install(
+            packages=packages,
+            jail=existing_jail
+        ))
         assert os.path.exists(f"{existing_jail.root_path}/usr/local/bin/sl")
-
         assert existing_jail.running is False
 
         pkg_mountpoint = existing_jail.root_path + "/.ioc-pkg"


### PR DESCRIPTION
- bootstrap the newest pkg archive found in the mirror cache

The local mirror cache was mistakenly searched for the first file that begins with `pkg` and ends with `.txz`. Instead the list of matches is sorted in descending order and the first item (the highest version) is returned. Also the package must start with `pkg-` (dash added).