### PR TITLE
fix calculation of devfs_rules (for DHCP)

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -654,7 +654,7 @@ class JailGenerator(JailResource):
             mountpoint="/dev",
             event=libioc.events.MountDevFS,
             event_scope=event_scope,
-            ruleset=self.config["devfs_ruleset"]
+            ruleset=self.devfs_ruleset
         )
 
     def __mount_fdescfs(

--- a/tests/test_VNET.py
+++ b/tests/test_VNET.py
@@ -142,3 +142,25 @@ class TestVNET(object):
             f"vnet7:{existing_jail.jid}"
         ]).decode("utf-8")
         assert mac_a in stdout
+
+    def test_devfs_ruleset_for_dhcp(
+        self,
+        existing_jail: 'libioc.Jail.Jail',
+        bridge_interface: str
+    ) -> None:
+        existing_jail.config["devfs_ruleset"] = 4
+        existing_jail.config["vnet"] = True
+        existing_jail.config["interfaces"] = f"vnet0:{bridge_interface}"
+
+        assert existing_jail.devfs_ruleset == 4
+        existing_jail.config["ip4_addr"] = "vnet0|dhcp"
+
+        assert existing_jail.devfs_ruleset > 4
+        stdout = subprocess.check_output([
+            "/sbin/devfs",
+            "rule",
+            "-s",
+            str(existing_jail.devfs_ruleset),
+            "show"
+        ]).decode("utf-8")
+        assert "bpf" in stdout

--- a/tests/test_VNET.py
+++ b/tests/test_VNET.py
@@ -164,3 +164,10 @@ class TestVNET(object):
             "show"
         ]).decode("utf-8")
         assert "bpf" in stdout
+
+        # disable DHCP, but set the calculated ruleset fixed
+        existing_jail.config["devfs_ruleset"] = existing_jail.devfs_ruleset
+        existing_jail.config["ip4_addr"] = None
+
+        existing_jail.start()
+        assert os.path.exists(f"{existing_jail.root_path}/dev/bpf")


### PR DESCRIPTION
- mount /dev with calculated devfs_rule rather than the config value