### PR TITLE
add a periodic.conf

### DIFF
--- a/libioc/Config/Jail/File/PeriodicConf.py
+++ b/libioc/Config/Jail/File/PeriodicConf.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017-2019, Stefan Grönke, Igor Galić
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Manage periodic.conf files."""
+import libioc.helpers
+import libioc.Config.Jail.File
+
+# MyPy
+import libioc.Logger
+
+
+class PeriodicConf(libioc.Config.Jail.File.ConfigFile):
+    """Model a periodic.conf file."""
+
+    _file: str = "/etc/periodic.conf"
+
+
+class ResourcePeriodicConf(libioc.Config.Jail.File.ResourceConfigFile):
+    """Model a periodic.conf file relative to a resource."""
+
+    _file: str = "/etc/periodic.conf"

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1461,11 +1461,17 @@ class JailGenerator(JailResource):
 
     def save(self) -> None:
         """Permanently save a jail's configuration."""
+        libioc.LaunchableResource.LaunchableResource.save(self)
         self._write_config(self.config.data)
         self._save_autoconfig()
 
     def _save_autoconfig(self) -> None:
-        """Save auto-generated files."""
+        """
+        Save auto-generated files.
+
+        Such files reflect changes to the JailConfig and need to be refreshed
+        before each jail start.
+        """
         self.rc_conf.save()
 
     def exec(

--- a/libioc/LaunchableResource.py
+++ b/libioc/LaunchableResource.py
@@ -193,3 +193,10 @@ class LaunchableResource(libioc.Resource.Resource):
             )
             self._sysctl_conf = sysctl_conf
         return self._sysctl_conf
+
+    def save(self) -> None:
+        """Permanently save the resource configuration."""
+        if self._periodic_conf is not None:
+            self._periodic_conf.save()
+        if self._sysctl_conf is not None:
+            self._sysctl_conf.save()

--- a/libioc/LaunchableResource.py
+++ b/libioc/LaunchableResource.py
@@ -37,6 +37,9 @@ class LaunchableResource(libioc.Resource.Resource):
     _rc_conf: typing.Optional[
         'libioc.Config.Jail.File.RCConf.ResourceRCConf'
     ]
+    _periodic_conf: typing.Optional[
+        'libioc.Config.Jail.File.PeriodicConf.ResourcePeriodicConf'
+    ]
     _sysctl_conf: typing.Optional[
         'libioc.Config.Jail.File.SysctlConf.SysctlConf'
     ]
@@ -65,6 +68,7 @@ class LaunchableResource(libioc.Resource.Resource):
         self._updater = None
         self._backup = None
         self._rc_conf = None
+        self._periodic_conf = None
         self._sysctl_conf = None
         self._updater = None
         self._backup = None
@@ -161,6 +165,20 @@ class LaunchableResource(libioc.Resource.Resource):
                 logger=self.logger
             )
         return self._rc_conf
+
+    @property
+    def periodic_conf(
+        self
+    ) -> 'libioc.Config.Jail.File.PeriodicConf.ResourcePeriodicConf':
+        """Return a lazy-loaded instance of the resources PeriodicConf."""
+        if self._periodic_conf is None:
+            import libioc.Config.Jail.File.PeriodicConf
+            PeriodicConf = libioc.Config.Jail.File.PeriodicConf
+            self._periodic_conf = PeriodicConf.ResourcePeriodicConf(
+                resource=self,
+                logger=self.logger
+            )
+        return self._periodic_conf
 
     @property
     def sysctl_conf(

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -762,9 +762,9 @@ class ReleaseGenerator(ReleaseResource):
         yield releaseConfigurationEvent.begin()
         try:
             if any([
-               self._set_default_periodic_conf(),
-               self._set_default_rc_conf(),
-               self._set_default_sysctl_conf()
+                    self._set_default_periodic_conf(),
+                    self._set_default_rc_conf(),
+                    self._set_default_sysctl_conf()
             ]):
                 release_changed = True
                 yield releaseConfigurationEvent.end()

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -216,12 +216,14 @@ class ReleaseGenerator(ReleaseResource):
         "sendmail_submit_enable": False,
         "sendmail_msp_queue_enable": False,
         "sendmail_outbound_enable": False,
+        "cron_flags": "-m ''",
+        "syslogd_flags": "-ss"
+    }
+    DEFAULT_PERIODIC_CONF: typing.Dict[str, typing.Union[str, bool]] = {
         "daily_clean_hoststat_enable": False,
         "daily_status_mail_rejects_enable": False,
         "daily_status_include_submit_mailq": False,
         "daily_submit_queuerun": False,
-        "cron_flags": "-m ''",
-        "syslogd_flags": "-ss"
     }
 
     DEFAULT_SYSCTL_CONF: typing.Dict[str, int] = {
@@ -969,6 +971,13 @@ class ReleaseGenerator(ReleaseResource):
             self.rc_conf[key] = value
 
         return self.rc_conf.save() is True
+
+    def _set_default_periodic_conf(self) -> bool:
+
+        for key, value in self.DEFAULT_PERIODIC_CONF.items():
+            self.periodic_conf[key] = value
+
+        return self.periodic_conf.save() is True
 
     def _set_default_sysctl_conf(self) -> bool:
 

--- a/tests/test_Release.py
+++ b/tests/test_Release.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017-2019, Stefan Grönke, Igor Galić
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the Release module."""
+import os.path
+
+import libioc.Release
+
+class TestRelease(object):
+    """Run Release unit tests."""
+
+    def test_periodoc_config_is_applied_to_fetched_releases(
+        self,
+        local_release: 'libioc.Release.ReleaseGenerator'
+    ) -> None:
+        periodic_conf_path = f"{local_release.root_path}/etc/periodic.conf"
+        assert os.path.exists(periodic_conf_path)
+
+        with open(periodic_conf_path, "r", encoding="UTF-8") as f:
+            content = f.read()
+            assert "daily_clean_hoststat_enable=\"NO\"" in content
+            assert "daily_status_mail_rejects_enable=\"NO\"" in content
+            assert "daily_status_include_submit_mailq=\"NO\"" in content
+            assert "daily_submit_queuerun=\"NO\"" in content


### PR DESCRIPTION
fixes #552
fixes #735

This PR adds a wrapper class to manage `periodic.conf`
and moves all `daily_*` flags from `rc.conf` to `periodic.conf`