### PR TITLE
Fix missing IOC_* env variables in Jail hooks

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -899,7 +899,7 @@ class JailGenerator(JailResource):
             if key not in _env_keys:
                 _env[key] = global_env[key]
 
-        return env
+        return _env
 
     def __run_hook(
         self,

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -310,7 +310,7 @@ class TestNullFSBasejail(object):
 
     def test_getstring_returns_empty_string_for_unknown_user_properties(
         self,
-        new_jail: 'libioc.Jail.Jail',
+        new_jail: 'libioc.Jail.Jail'
     ) -> None:
         """Test if getstring for an unknown user property is empty."""
         assert new_jail.getstring("user.unknown_propery") == ""


### PR DESCRIPTION
closes #342

Env variables from the `JailGenerator.env` did no longer show up in Jail Hook env variables.

- Feed correctly merged JailGenerator.env to Jail hooks
- Test that IOC_ env variables exist in every JailHook event that has finished

This regression was introduced with https://github.com/bsdci/libioc/commit/2e13eb06cf5b459b23124028bb3d324d5e9e306c