### PR TITLE
enhance resource name validation

### DIFF
--- a/libioc/Filter.py
+++ b/libioc/Filter.py
@@ -175,7 +175,7 @@ class Term(list):
             if char not in globs:
                 filter_string_without_globs += char
 
-        return libioc.helpers.validate_name(
+        return libioc.helpers.is_valid_name(
             filter_string_without_globs
         ) is True
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -1206,7 +1206,7 @@ class JailGenerator(JailResource):
         self.require_jail_stopped()
         self.require_storage_backend()
 
-        if libioc.helpers.validate_name(new_name) is False:
+        if libioc.helpers.is_valid_name(new_name) is False:
             raise libioc.errors.InvalidJailName(
                 name=new_name,
                 logger=self.logger

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -2286,7 +2286,8 @@ class JailGenerator(JailResource):
     def identifier(self) -> str:
         """Return the jail id used in snapshots, jls, etc."""
         config = object.__getattribute__(self, 'config')
-        return f"{self.source}-{config['id']}"
+        escaped_jail_id = config['id'].replace(".", "*")
+        return f"{self.source}-{escaped_jail_id}"
 
     @property
     def release(self) -> 'libioc.Release.ReleaseGenerator':

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -276,7 +276,7 @@ class ReleaseGenerator(ReleaseResource):
             else:
                 root_datasets_name = resource_selector.source_name
 
-        if libioc.helpers.validate_name(resource_selector.name) is False:
+        if libioc.helpers.is_valid_name(resource_selector.name) is False:
             raise NameError(f"Invalid 'name' for Release: '{name}'")
 
         self.name = name

--- a/libioc/ResourceSelector.py
+++ b/libioc/ResourceSelector.py
@@ -64,8 +64,8 @@ class ResourceSelector:
             _source_name = None
 
         _name_without_globs = _name.replace("*", "").replace("+", "")
-        has_valid_name = libioc.helpers.validate_name(_name_without_globs)
-        is_valid_uuid = libioc.helpers.is_uuid(_name_without_globs)
+        has_valid_name = libioc.helpers.is_valid_name(_name_without_globs)
+        is_valid_uuid = libioc.helpers.is_valid_uuid(_name_without_globs)
         if (_name not in ["*", "+"]) and not (has_valid_name or is_valid_uuid):
             raise libioc.errors.InvalidJailName(name=_name, logger=self.logger)
 

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -393,7 +393,8 @@ class InvalidJailName(JailConfigError):
     ) -> None:
         msg = (
             f"Invalid jail name '{name}': "
-            "Names may only contain alphanumeric characters and dash"
+            "Names may only contain alphanumeric characters and may not begin "
+            "with special characters ! ^ - _ ( ) [ ] { } < > ,"
         )
         if invalid_characters is not None:
             msg += ", but got " + str("".join(invalid_characters) + "")

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -393,8 +393,9 @@ class InvalidJailName(JailConfigError):
     ) -> None:
         msg = (
             f"Invalid jail name '{name}': "
-            "Names may only contain alphanumeric characters and may not begin "
-            "with special characters ! ^ - _ ( ) [ ] { } < > , ."
+            "Names may not begin or end with special characters, "
+            "but may contain alphanumeric and allowed special characters "
+            "! ^ - _ ( ) [ ] { } < > , ."
         )
         if invalid_characters is not None:
             msg += ", but got " + str("".join(invalid_characters) + "")

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -394,7 +394,7 @@ class InvalidJailName(JailConfigError):
         msg = (
             f"Invalid jail name '{name}': "
             "Names may only contain alphanumeric characters and may not begin "
-            "with special characters ! ^ - _ ( ) [ ] { } < > ,"
+            "with special characters ! ^ - _ ( ) [ ] { } < > , ."
         )
         if invalid_characters is not None:
             msg += ", but got " + str("".join(invalid_characters) + "")

--- a/libioc/helpers.py
+++ b/libioc/helpers.py
@@ -139,7 +139,7 @@ def _prettify_output(output: str) -> str:
 
 def to_humanreadable_name(name: str) -> str:
     """Return a shorted UUID or the original name."""
-    return name[:8] if (is_uuid(name) is True) else name
+    return name[:8] if (is_valid_uuid(name) is True) else name
 
 
 _UUID_REGEX = re.compile(
@@ -147,18 +147,22 @@ _UUID_REGEX = re.compile(
 )
 
 
-def is_uuid(text: str) -> bool:
+def is_valid_uuid(text: str) -> bool:
     """Return True if the input string is an UUID."""
     return _UUID_REGEX.match(text) is not None
 
 
 # helper function to validate names
-_validate_name = re.compile(r"[a-z0-9][a-z0-9\.\-_]{1,31}", re.I)
+_JAIL_NAME_REGEX = re.compile(
+    r"^[A-Za-z0-9]+(?:[!\-_^\[\]\{\}\(\)<>\.,]?[A-Za-z0-9\u00C0-\u017F]+)*$"
+)
 
 
-def validate_name(name: str) -> bool:
+def is_valid_name(name: str) -> bool:
     """Return True if the name matches the naming convention."""
-    return _validate_name.fullmatch(name) is not None
+    if len(name) > 31:
+        return False
+    return _JAIL_NAME_REGEX.fullmatch(name) is not None
 
 
 def parse_none(

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -73,12 +73,12 @@ class TestJailConfig(object):
         assert "foobar" in data["user"].keys()
         assert isinstance(data["user"]["foobar"], str)
 
-    def test_name_may_not_contain_dots(
+    def test_name_may_contain_dots(
         self,
         existing_jail: 'libioc.Jail.Jail'
     ) -> None:
-        with pytest.raises(libioc.errors.InvalidJailName):
-            existing_jail.config["name"] = "jail.with.dots"
+        existing_jail.config["name"] = "jail.with.dots"
+        existing_jail.identifier = "jail*with*dots"
 
     def test_cannot_clone_from_dict_with_invalid_values(
         self,

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -85,7 +85,7 @@ class TestJailConfig(object):
         new_jail: 'libioc.Jail.Jail'
     ) -> None:
         invalid_data = dict(
-            name="name.with.dots"
+            name="invalid*characters"
         )
         del new_jail.config["id"]
         with pytest.raises(libioc.errors.InvalidJailName):

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -78,7 +78,7 @@ class TestJailConfig(object):
         existing_jail: 'libioc.Jail.Jail'
     ) -> None:
         existing_jail.config["name"] = "jail.with.dots"
-        existing_jail.identifier = "jail*with*dots"
+        assert existing_jail.identifier.endswith("jail*with*dots")
 
     def test_cannot_clone_from_dict_with_invalid_values(
         self,

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -339,3 +339,30 @@ class TestNullFSBasejail(object):
                 assert "\nIOC_" in event.stdout
             if isinstance(event, libioc.events.JailHookPoststart) is True:
                 assert f"IOC_JID={jail.jid}" in event.stdout
+
+    def test_jail_name_validation(self) -> None:
+        assert libioc.helpers.is_valid_name("ioc") is True
+        assert libioc.helpers.is_valid_name("ioc23") is True
+        assert libioc.helpers.is_valid_name("23ioc") is True
+        assert libioc.helpers.is_valid_name("ioc-23") is True
+        assert libioc.helpers.is_valid_name("23-ioc") is True
+        assert libioc.helpers.is_valid_name("ioc!jail") is True
+        assert libioc.helpers.is_valid_name("ci-bsd!ioc") is True
+        assert libioc.helpers.is_valid_name("IOC") is True
+        assert libioc.helpers.is_valid_name("IoC23") is True
+        assert libioc.helpers.is_valid_name("Grönke") is True
+        assert libioc.helpers.is_valid_name("jail>ioc") is True
+        assert libioc.helpers.is_valid_name("jail{ioc}23") is True
+
+        assert libioc.helpers.is_valid_name("") is False
+        assert libioc.helpers.is_valid_name("ioc\n23") is False
+        assert libioc.helpers.is_valid_name("ioc\t23") is False
+        assert libioc.helpers.is_valid_name("ioc-") is False
+        assert libioc.helpers.is_valid_name("!ioc") is False
+        assert libioc.helpers.is_valid_name("@gronke") is False
+        assert libioc.helpers.is_valid_name("stefan@gronke") is False
+        assert libioc.helpers.is_valid_name("23-ioc-") is False
+        assert libioc.helpers.is_valid_name("white space") is False
+        assert libioc.helpers.is_valid_name("ioc\\jail") is False
+        assert libioc.helpers.is_valid_name("jail{ioc}") is False
+        assert libioc.helpers.is_valid_name("we❤jails") is False


### PR DESCRIPTION
addresses #483 

- be more strict with jail names
- allow certain special characters in jail names `! ^ - _ ( ) [ ] { } < > , .`
