### PR TITLE
allow . in package names

### DIFF
--- a/libioc/Pkg.py
+++ b/libioc/Pkg.py
@@ -431,7 +431,7 @@ class Pkg:
         packages: typing.Union[str, typing.List[str]]
     ) -> typing.List[str]:
         _packages = [packages] if isinstance(packages, str) else packages
-        pattern = re.compile(r"^(?:[A-z0-9](?:[A-z0-9\-\/]?[A-z0-9])*)+$")
+        pattern = re.compile(r"^(?:[A-z0-9](?:[A-z0-9\-\/\.]?[A-z0-9])*)+$")
         for package in _packages:
             if pattern.match(package) is None:
                 raise libioc.errors.SecurityViolation(


### PR DESCRIPTION
fixes #743

Before `.` (dot) was not allowed in FreeBSD package names maintained by libioc. This changes allow the character to be used as infix of package names.


