### PR TITLE
Fix starting nested jails without devfs_ruleset

### DIFF
--- a/libioc/ResourceUpdater.py
+++ b/libioc/ResourceUpdater.py
@@ -128,6 +128,7 @@ class Updater:
                     "release": self.release.name,
                     "exec_start": None,
                     "securelevel": "0",
+                    "devfs_ruleset": None,
                     "allow_chflags": True,
                     "vnet": False,
                     "ip4_addr": None,

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019, Stefan Grönke
+2# Copyright (c) 2017-2019, Stefan Grönke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -249,6 +249,16 @@ class TestUserDefaultConfig(object):
             assert "comment" in data["user"].keys()
             assert data["user"]["comment"] == "hi there!"
             assert len(data.keys()) == 2
+
+    def test_can_be_configured_without_devfs_ruleset(
+        self,
+        existing_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        assert existing_jail.config["devfs_ruleset"] == 4
+        assert "devfs_ruleset" in existing_jail._launch_params
+
+        existing_jail.config["devfs_ruleset"] = None
+        assert "devfs_ruleset" not in existing_jail._launch_params
 
 
 class TestBrokenConfig(object):


### PR DESCRIPTION
- allow starting jails without any devfs_ruleset (`None`)