### PR TITLE
Fix MyPy issues introduced with a new version on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ uninstall:
 	fi
 check:
 	flake8 --version
-	flake8 --exclude=".travis,.eggs,__init__.py,docs,tests" --ignore=E203,E252,W391,D107,A001,A002,A003,A004,D412,D413
+	flake8 --exclude=".travis,.eggs,__init__.py,docs,tests" --ignore=E203,E252,W391,D107,A001,A002,A003,A004,D412,D413,T499
 	bandit --skip B404,B110 --exclude tests/ -r .
 test:
 	pytest tests --zpool $(ZPOOL)

--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -80,7 +80,7 @@ class FstabLine(dict):
 
         return output
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore
         """Compare FstabLine by its destination."""
         return hash(self["destination"])
 
@@ -125,7 +125,7 @@ class FstabCommentLine(dict):
         """Return the untouched comment line string."""
         return str(self["line"])
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore
         """
         Return a random hash value.
 
@@ -144,7 +144,7 @@ class FstabAutoPlaceholderLine(dict):
         """Never print virtual lines."""
         raise NotImplementedError("this is a virtual fstab line")
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # type: ignore
         """Do not return a hash because placeholders have none."""
         return hash(None)
 


### PR DESCRIPTION
- suppress MyPy tracebacks in flake8 output
- ignore typing of Fstab.__hash__ conflictig with dict.__hash__ signature