### PR TITLE
Correct hostuuid handling

### DIFF
--- a/libioc/Config/Jail/BaseConfig.py
+++ b/libioc/Config/Jail/BaseConfig.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """The common base of jail configurations."""
 import typing
+import uuid
 
 import libioc.Config.Data
 import libioc.Config.Jail.Globals
@@ -536,14 +537,25 @@ class BaseConfig(dict):
                     logger=self.logger
                 )
 
-    def _get_host_hostuuid(self) -> str:
-        try:
-            hostuuid = self.data["host_hostuuid"]
-            if hostuuid is None:
-                raise ValueError
-            return str(hostuuid)
-        except (KeyError, ValueError):
-            return str(self["id"])
+    def _get_host_hostuuid(self) -> typing.Optional[uuid.UUID]:
+        host_hostuuid = self.data["host_hostuuid"]  # type: uuid.UUID
+        return host_hostuuid
+
+    def _set_host_hostuuid(
+        self,
+        value: typing.Optional[typing.Union[str, uuid.UUID]]
+    ) -> None:
+        if (value is None) or (isinstance(value, uuid.UUID) is True):
+            self.data["host_hostuuid"] = value
+            return
+
+        if isinstance(value, str) is True:
+            _value = str(value)
+        elif isinstance(value, bytes) is True:
+            _value = value.decode("UTF-8")  # type: ignore
+        else:
+            raise ValueError("Expected UUID or string/byte representation")
+        self.data["host_hostuuid"] = uuid.UUID(_value)
 
     def _get_host_hostname(self) -> str:
         try:

--- a/libioc/Host.py
+++ b/libioc/Host.py
@@ -28,6 +28,7 @@ import os
 import platform
 import re
 import freebsd_sysctl
+import uuid
 
 import libzfs
 
@@ -45,6 +46,7 @@ _distribution_types = typing.Union[
     libioc.Distribution.DistributionGenerator,
     libioc.Distribution.Distribution,
 ]
+UUID = uuid.UUID
 
 
 class HostGenerator:
@@ -55,7 +57,6 @@ class HostGenerator:
     _devfs: libioc.DevfsRules.DevfsRules
     _defaults: libioc.Resource.DefaultResource
     __user_provided_defaults: typing.Optional[libioc.Resource.DefaultResource]
-    __hostid: str
     releases_dataset: libzfs.ZFSDataset
     datasets: libioc.Datasets.Datasets
     distribution: _distribution_types
@@ -117,17 +118,9 @@ class HostGenerator:
         self._defaults.read_config()
 
     @property
-    def id(self) -> str:
-        """Return the hostid and memoize on first lookup."""
-        try:
-            return self.__hostid
-        except AttributeError:
-            pass
-
-        with open("/etc/hostid", "r", encoding="utf-8") as f:
-            self.__hostid = f.read().strip()
-
-        return self.__hostid
+    def uuid(self) -> UUID:
+        """Return the hostuuid and memoize on first lookup."""
+        return uuid.UUID(freebsd_sysctl.Sysctl("kern.hostuuid").value)
 
     @property
     def defaults(self) -> 'libioc.Resource.DefaultResource':

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Collection of iocage errors."""
 import typing
+import uuid
 
 # MyPy
 import libzfs  # noqa: F401
@@ -495,19 +496,19 @@ class ResourceLimitActionFailed(IocException, KeyError):
         IocException.__init__(self, message=msg, logger=logger)
 
 
-class JailHostIdMismatch(JailException):
+class JailHostUUIDMismatch(JailException):
     """Raised when attempting to start a jail with mismatching hostid."""
 
     def __init__(
         self,
-        host_hostid: str,
+        hostuuid: uuid.UUID,
         jail: 'libioc.Jail.JailGenerator',
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
         jail_hostid = jail.config["hostid"]
         msg = (
             f"The jail hostid '{jail_hostid}' "
-            f"does not match the hosts hostid '{host_hostid}'"
+            f"does not match the hosts hostid '{hostuuid}'"
         )
         JailException.__init__(self, message=msg, jail=jail, logger=logger)
 

--- a/tests/test_Config.py
+++ b/tests/test_Config.py
@@ -26,6 +26,8 @@ import typing
 import pytest
 import json
 import os
+import uuid
+import hashlib
 
 import libzfs
 
@@ -259,6 +261,25 @@ class TestUserDefaultConfig(object):
 
         existing_jail.config["devfs_ruleset"] = None
         assert "devfs_ruleset" not in existing_jail._launch_params
+
+    def test_hostuuid_is_generated_when_not_configured(
+        self,
+        new_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        assert new_jail.config["host_hostuuid"] == None
+        assert isinstance(new_jail.hostuuid, uuid.UUID)
+
+    def test_hostuuid_can_be_configured(
+        self,
+        new_jail: 'libioc.Jail.Jail'
+    ) -> None:
+        m = hashlib.sha1()  # nosec: B303
+        m.update(b"some random value")
+        test_uuid = uuid.UUID(m.hexdigest()[0:32])
+
+        new_jail.config["host_hostuuid"] = str(test_uuid)
+        assert isinstance(new_jail.hostuuid, uuid.UUID)
+        assert new_jail.hostuuid == test_uuid
 
 
 class TestBrokenConfig(object):


### PR DESCRIPTION
### Enhancements
- load Host.uuid from sysctl rather than /etc/hostid
- strictly handle host_hostuuid as uuid.UUID

### Bugs
- fix nested jails attempt to non-existing `/etc/hostid` file