### PR TITLE
use ctypes.CDLL() directly instead of find_library

### DIFF
--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -71,7 +71,11 @@ import libioc.Config.Jail.File.Fstab
 
 import ctypes
 import errno
-_dll = ctypes.CDLL("libc.so.7", use_errno=True)
+try:
+    _dll = ctypes.CDLL("libc.so.7", use_errno=True)
+except:
+    import ctypes.util
+    _dll = ctypes.CDLL(str(ctypes.util.find_library("c")), use_errno=True)
 
 
 class JailResource(

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -73,7 +73,7 @@ import ctypes
 import errno
 try:
     _dll = ctypes.CDLL("libc.so.7", use_errno=True)
-except:
+except OSError:
     import ctypes.util
     _dll = ctypes.CDLL(str(ctypes.util.find_library("c")), use_errno=True)
 

--- a/libioc/Jail.py
+++ b/libioc/Jail.py
@@ -69,9 +69,9 @@ import libioc.Config.Jail.Properties.ResourceLimit
 import libioc.ResourceSelector
 import libioc.Config.Jail.File.Fstab
 
-import ctypes.util
+import ctypes
 import errno
-_dll = ctypes.CDLL(str(ctypes.util.find_library("c")), use_errno=True)
+_dll = ctypes.CDLL("libc.so.7", use_errno=True)
 
 
 class JailResource(


### PR DESCRIPTION
This should be more efficient, as it doesn't need to call `ldconfig`,
`gcc`, `objdump` or `ld` to determine its existence.
`ctypes.CDDL()` will use `dlopen()` directly.

Note that we're hard-coding the current version (`libc.so.7`).
This will need changing when FreeBSD changes their ABI.

At that point we might have to rethink our strategy, or fix
`ctypes.util.find_library()` to be less awful.
Until then, this should give us a minimal performance boost.