### PR TITLE
explicitly type fcntl.ioctl function

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   freebsd_instance:
     matrix:
       #image: freebsd-11-2-release-amd64
-      image: freebsd-12-0-release-amd64
+      image: freebsd-12-1-release-amd64
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script: cat requirements*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,8 @@ task:
     zfs set compression=lz4 "ioc-test-`uname -r`"
   install_script:
     - mount -t fdescfs null /dev/fd
+    - pkg bootstrap
+    - pkg update -f
     - pkg install -y git
     - make install-dev
   test_script:

--- a/libioc/helpers_ioctl.py
+++ b/libioc/helpers_ioctl.py
@@ -41,7 +41,12 @@ def get_sockio_ioctl(nic_name: str, ioctl: SOCKIO_IOCTLS) -> bytes:
     """Query a sockio ioctl for a given NIC."""
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0) as sock:
         ifconf = struct.pack('256s', nic_name.encode("UTF-8")[:15])
-        return bytes(fcntl.ioctl(sock.fileno(), ioctl.value, ifconf))
+        return bytes(fcntl.ioctl(
+            sock.fileno(),
+            int(ioctl.value),
+            bytes(ifconf),
+            True
+        ))
 
 
 def get_interface_ip4_address(nic_name: str) -> ipaddress.IPv4Address:


### PR DESCRIPTION
Explicitly types the fcntl.ioctl method arguments. Fixes an issue reported by MyPy.

Should be fixed with the next MyPy release:
https://github.com/python/typeshed/commit/009b269882b6b7befdf3ee5ad9f35caf550219ff

The fix was published on 2020-03-24 while MyPy 0.770 was releases 4 days earlier.

