### PR TITLE
shuffle dependencies installation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
     - sysrc -a
     - sysctl -a
     - mount -t fdescfs null /dev/fd
-    - pkg install -y git
+    - pkg install -y git-lite
     - make install-dev
   test_script:
     - env ZPOOL="ioc-test-`uname -r`" make test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,6 @@ task:
     - sysrc -a
     - sysctl -a
     - mount -t fdescfs null /dev/fd
-    - pkg install -y git-lite
     - make install-dev
   test_script:
     - env ZPOOL="ioc-test-`uname -r`" make test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
     - sysrc -a
     - sysctl -a
     - mount -t fdescfs null /dev/fd
+    - pkg install -y python3
     - make install-dev
   test_script:
     - env ZPOOL="ioc-test-`uname -r`" make test

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install-python-requirements:
 install-python-requirements-dev: install-python-requirements
 	$(PYTHON) -m pip install -Ur requirements-dev.txt
 install-deps:
-	pkg install -q -y libucl py$(pyver)-ucl rsync python$(pyver) py$(pyver)-libzfs
+	pkg install -q -y libucl rsync py$(pyver)-ucl py$(pyver)-gitdb2 py$(pyver)-libzfs
 install-deps-dev: install-deps
 	if [ "`uname`" = "FreeBSD" ]; then pkg install -y gmake py$(pyver)-setuptools py$(pyver)-sqlite3; fi
 install-dev: install-deps-dev install-python-requirements-dev

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ install-python-requirements:
 install-python-requirements-dev: install-python-requirements
 	$(PYTHON) -m pip install -Ur requirements-dev.txt
 install-deps:
-	pkg install -q -y libucl py$(pyver)-ucl py$(pyver)-setuptools rsync python$(pyver) py$(pyver)-libzfs
+	pkg install -q -y libucl py$(pyver)-ucl rsync python$(pyver) py$(pyver)-libzfs
 install-deps-dev: install-deps
-	if [ "`uname`" = "FreeBSD" ]; then pkg install -y gmake py$(pyver)-sqlite3; fi
+	if [ "`uname`" = "FreeBSD" ]; then pkg install -y gmake py$(pyver)-setuptools py$(pyver)-sqlite3; fi
 install-dev: install-deps-dev install-python-requirements-dev
 	$(PYTHON) -m pip install -e .
 install-travis:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ JAIL_NET?=16
 MYPYPATH = $(shell pwd)/.travis/mypy-stubs
 
 PYTHON_VERSION ?= $(TRAVIS_PYTHON_VERSION)
-SELECTED_PYTHON_VERSION != if [ "$(PYTHON_VERSION)" != "" ]; then echo $(PYTHON_VERSION); else pkg info -g 'python3*' | cut -d'-' -f1 | sed 's/^python//' | sort -n | tail -n1 | sed -r 's/^([0-9])([0-9]+)/\1.\2/'; fi
+SELECTED_PYTHON_VERSION != if [ "$(PYTHON_VERSION)" != "" ]; then echo $(PYTHON_VERSION); else pkg query '%dn' 'python3' | sort -un | sed -r 's/^python//;s/^([0-9])([0-9]+)/\1.\2/' | tail -n1 ; fi
 PYTHON ?= python${SELECTED_PYTHON_VERSION}
 # turn python3.7 -> 3.7 -> 37
 pyver= ${PYTHON:S/^python//:S/.//:C/\([0-9]+\)/\1/}

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install-python-requirements:
 install-python-requirements-dev: install-python-requirements
 	$(PYTHON) -m pip install -Ur requirements-dev.txt
 install-deps:
-	pkg install -q -y libucl rsync py$(pyver)-ucl py$(pyver)-gitdb2 py$(pyver)-libzfs
+	pkg install -q -y libucl rsync git py$(pyver)-ucl py$(pyver)-libzfs
 install-deps-dev: install-deps
 	if [ "`uname`" = "FreeBSD" ]; then pkg install -y gmake py$(pyver)-setuptools py$(pyver)-sqlite3; fi
 install-dev: install-deps-dev install-python-requirements-dev


### PR DESCRIPTION
Install python3 so we'll get the default python3 installed!
That way we can now actually figure out, for real, which the default python3 is!

We also don't need `setuptools` in the standard target, so it's now moved to`install-deps-dev`.