### PR TITLE
fix setup.py parse_requirements

### DIFF
--- a/libioc/Config/Data.py
+++ b/libioc/Config/Data.py
@@ -150,7 +150,7 @@ class Data(dict):
         return typing.cast(typing.ValuesView[typing.Any], self.__values())
 
     def __values(self) -> typing.Iterator[typing.Any]:
-        yield from (value for _, value in self.__iter__())
+        yield from (value for _, value in self.items())
 
     def items(self) -> typing.ItemsView[str, typing.Any]:
         """Iterate over the flattened keys and values."""

--- a/libioc/Distribution.py
+++ b/libioc/Distribution.py
@@ -140,7 +140,7 @@ class DistributionGenerator:
             release_path = f"/ftp/releases/{processor}/{processor}"
             return f"https://download.freebsd.org{release_path}"
         elif distribution == "HardenedBSD":
-            return f"https://jenkins.hardenedbsd.org/builds"
+            return "https://jenkins.hardenedbsd.org/builds"
         else:
             raise libioc.errors.DistributionUnknown(distribution)
 

--- a/libioc/Provisioning/puppet.py
+++ b/libioc/Provisioning/puppet.py
@@ -268,7 +268,7 @@ def __write_r10k_config(
     with __securely_open_r10k_config(jail) as f:
         jail.logger.verbose(f"Writing r10k config {f.name}")
         f.write("\n".join((
-            f"---",
+            "---",
             ":sources:",
             "    puppet:",
             f"       basedir: {basedir}",

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -158,7 +158,7 @@ class JailNotSupplied(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"Please supply a jail"
+        msg = "No jail supplied"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -292,7 +292,7 @@ class JailStateUpdateFailed(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"JLS query failed"
+        msg = "JLS query failed"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -306,7 +306,7 @@ class VirtualFstabLineHasNoRealIndex(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"The virtual fstab line does not have a real list index"
+        msg = "The virtual fstab line does not have a real list index"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -480,7 +480,7 @@ class ResourceLimitUnknown(IocException, KeyError):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"The specified resource limit is unknown"
+        msg = "The specified resource limit is unknown"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -627,7 +627,7 @@ class ListableResourceNamespaceUndefined(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"The ListableResource needs a namespace for this operation"
+        msg = "The ListableResource needs a namespace for this operation"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -754,7 +754,7 @@ class HostReleaseUnknown(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"The host release is unknown"
+        msg = "The host release is unknown"
         super().__init__(message=msg, logger=logger)
 
 
@@ -765,7 +765,7 @@ class HostUserlandVersionUnknown(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"Could not determine the hosts userland version"
+        msg = "Could not determine the hosts userland version"
         super().__init__(message=msg, logger=logger)
 
 
@@ -1156,7 +1156,7 @@ class ReleaseListUnavailable(IocException):
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
 
-        msg = f"The releases list is unavailable"
+        msg = "The releases list is unavailable"
         super().__init__(message=msg, logger=logger)
 
 
@@ -1168,7 +1168,7 @@ class ReleaseAssetHashesUnavailable(IocException):
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
 
-        msg = f"The releases asset hashes are unavailable"
+        msg = "The releases asset hashes are unavailable"
         super().__init__(message=msg, logger=logger)
 
 
@@ -1216,7 +1216,7 @@ class NonReleaseUpdateFetch(UpdateFailure):
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
 
-        msg = f"Updates can only be fetched for releases"
+        msg = "Updates can only be fetched for releases"
         UpdateFailure.__init__(
             self,
             name=resource.name,
@@ -1448,7 +1448,7 @@ class UndefinedProvisionerSource(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"Missing provisioner source"
+        msg = "Missing provisioner source"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -1459,7 +1459,7 @@ class UndefinedProvisionerMethod(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"Missing provisioner method"
+        msg = "Missing provisioner method"
         IocException.__init__(self, message=msg, logger=logger)
 
 
@@ -1487,5 +1487,5 @@ class SourceNotFound(IocException):
         self,
         logger: typing.Optional['libioc.Logger.Logger']=None
     ) -> None:
-        msg = f"Jail source not found"
+        msg = "Jail source not found"
         super().__init__(message=msg, logger=logger)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gitpython
 freebsd_sysctl==0.0.7
-jail==0.0.11
+jail==0.0.12

--- a/setup.py
+++ b/setup.py
@@ -38,16 +38,19 @@ except ImportError:
     pass
 
 
+def _resolve_requirement(req: typing.Any) -> str:
+    if req.__class__.__name__ == "ParsedRequirement":
+        return str(req.requirement)
+    else:
+        return f"{req.name}{req.specifier}"
+
+
 def _read_requirements(
     filename: str="requirements.txt"
 ) -> typing.Dict[str, typing.List[str]]:
     reqs = list(parse_requirements(filename, session="libioc"))
     return dict(
-        install_requires=list(map(lambda x: f"{x.name}{x.specifier}", reqs)),
-        dependency_links=list(map(
-            lambda x: str(x.link),
-            filter(lambda x: x.link, reqs)
-        ))
+        install_requires=[_resolve_requirement(req) for req in reqs]
     )
 
 
@@ -73,7 +76,6 @@ setup(
     package_data={'': ['VERSION']},
     include_package_data=True,
     install_requires=ioc_requirements["install_requires"],
-    dependency_links=ioc_requirements["dependency_links"],
     # setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov', 'pytest-pep8']
 )


### PR DESCRIPTION
Pip has recently switched to a ParsedRequirement class with a different interface.

see https://github.com/pypa/pip/commit/f2e49b3946423c07a46398f691f721771b80b38a