### PR TITLE
Fix the six error-path crashes from the revival findings

### DIFF
--- a/libioc/Distribution.py
+++ b/libioc/Distribution.py
@@ -235,13 +235,12 @@ class DistributionGenerator:
 
             response_code = response.getcode()
             if response_code != 200:
-                # DownloadFailed takes no topic argument, so that this
-                # call raises a TypeError when it is reached
-                libioc.errors.DownloadFailed(  # type: ignore[call-arg]
-                    topic="EOL Warnings",
+                # constructing the error logs the warning without raising
+                libioc.errors.DownloadFailed(
+                    url=self.eol_url,
                     code=response_code,
                     logger=self.logger,
-                    level="warning"
+                    level="warn"
                 )
                 return []
 

--- a/libioc/NetworkInterface.py
+++ b/libioc/NetworkInterface.py
@@ -193,12 +193,14 @@ class NetworkInterface:
 
     def _destroy_interfaces(self, nic_names: typing.List[str]) -> None:
         for nic_name_to_destroy in nic_names:
-            # there is no libioc.helper module, so this raises
-            libioc.helper.exec([  # type: ignore[attr-defined]
-                self.ifconfig_command,
-                nic_name_to_destroy,
-                "destroy"
-            ])
+            libioc.helpers.exec(
+                [
+                    self.ifconfig_command,
+                    nic_name_to_destroy,
+                    "destroy"
+                ],
+                logger=self.logger
+            )
 
     def apply_addresses(self) -> None:
         """Apply the configured IP addresses."""

--- a/libioc/Provisioning/__init__.py
+++ b/libioc/Provisioning/__init__.py
@@ -160,9 +160,7 @@ class Provisioner(Prototype):
         method: str = self.jail.config["provision.method"]
         if method in self.__available_provisioning_modules:
             return method
-        # InvalidProvisionerMethod is missing from libioc.errors, so that
-        # this raise statement fails with an AttributeError when reached
-        raise libioc.errors.InvalidProvisionerMethod(  # type: ignore[attr-defined] # noqa: E501
+        raise libioc.errors.InvalidProvisionerMethod(
             method,
             logger=self.jail.logger
         )

--- a/libioc/Release.py
+++ b/libioc/Release.py
@@ -1039,10 +1039,8 @@ class ReleaseGenerator(ReleaseResource):
                 f"Asset {asset_name}.txz has an invalid signature"
                 f"(was '{local_file_hash}' but expected '{expected_hash}')"
             )
-            # InvalidReleaseAssetSignature expects the keyword name, so
-            # this raise crashes with a TypeError when reached
-            raise libioc.errors.InvalidReleaseAssetSignature(  # type: ignore[call-arg] # noqa: E501
-                release_name=self.name,
+            raise libioc.errors.InvalidReleaseAssetSignature(
+                name=self.name,
                 asset_name=asset_name,
                 logger=self.logger
             )

--- a/libioc/Storage/Standalone.py
+++ b/libioc/Storage/Standalone.py
@@ -41,12 +41,7 @@ class StandaloneJailStorage(libioc.Storage.Storage):
     ) -> typing.Generator['libioc.events.IocEvent', None, None]:
         """Attach the jail storage."""
         message = "Standalone jails do not require storage operations to start"
-        # Logger.warn accepts no jail argument, so this call crashes
-        # with a TypeError when reached (suspected leftover)
-        self.logger.warn(  # type: ignore[call-arg]
-            message,
-            jail=self.jail
-        )
+        self.logger.warn(message)
         raise NotImplementedError(message)
 
     def setup(

--- a/libioc/Storage/ZFSBasejail.py
+++ b/libioc/Storage/ZFSBasejail.py
@@ -48,10 +48,9 @@ class ZFSBasejailStorage(libioc.Storage.Basejail.BasejailStorage):
                 self.jail.cloned_release
             )
 
-        # libioc.events only offers BasejailStorageConfig, so this line
-        # raises an AttributeError when reached (suspected typo)
-        event = libioc.events.BaseJailStorageConfig(  # type: ignore[attr-defined] # noqa: E501
+        event = libioc.events.BasejailStorageConfig(
             jail=self.jail,
+            scope=event_scope
         )
         yield event.begin()
 

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -1209,7 +1209,8 @@ class InvalidReleaseAssetSignature(UpdateFailure):
         UpdateFailure.__init__(
             self,
             name=name,
-            reason=msg
+            reason=msg,
+            logger=logger
         )
 
 

--- a/libioc/errors.py
+++ b/libioc/errors.py
@@ -1470,6 +1470,18 @@ class UndefinedProvisionerMethod(IocException):
         IocException.__init__(self, message=msg, logger=logger)
 
 
+class InvalidProvisionerMethod(IocException):
+    """Raised when a provisioner method is unknown."""
+
+    def __init__(
+        self,
+        method: str,
+        logger: typing.Optional['libioc.Logger.Logger']=None
+    ) -> None:
+        msg = f"Invalid provisioner method: {method}"
+        IocException.__init__(self, message=msg, logger=logger)
+
+
 # Sources
 
 

--- a/tests/test_Distribution.py
+++ b/tests/test_Distribution.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, the libioc contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Unit tests for the Distribution module."""
+import typing
+import unittest.mock
+
+import libioc.Distribution
+import libioc.Host
+import libioc.Logger
+import libioc.ZFS
+
+
+class TestEOLList(object):
+    """Run tests for the end-of-life release list."""
+
+    def test_failed_eol_download_warns_instead_of_crashing(
+        self,
+        logger: 'libioc.Logger.Logger',
+        mocker: typing.Any
+    ) -> None:
+        distribution = libioc.Distribution.Distribution(
+            host=unittest.mock.Mock(spec=libioc.Host.HostGenerator),
+            zfs=unittest.mock.Mock(spec=libioc.ZFS.ZFS),
+            logger=logger
+        )
+
+        response = unittest.mock.MagicMock()
+        response.getcode.return_value = 503
+        urlopen = mocker.patch("urllib.request.urlopen")
+        urlopen.return_value.__enter__.return_value = response
+        warn = mocker.spy(logger, "warn")
+
+        assert distribution._query_eol_list() == []
+        assert warn.call_count == 1

--- a/tests/test_Network.py
+++ b/tests/test_Network.py
@@ -22,10 +22,12 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for non-VNET jails."""
+import typing
 import ipaddress
 import subprocess
 
 import libioc.Jail
+import libioc.NetworkInterface
 
 class TestNetwork(object):
     """Run tests for non-VNET networking."""
@@ -103,3 +105,30 @@ class TestNetwork(object):
         assert str(ip4_addr2.ip) not in stdout
         assert str(ip6_addr1.ip) not in stdout
         assert str(ip6_addr2.ip) not in stdout
+
+
+class TestNetworkInterfaceDestroy(object):
+    """Run tests for network interface destruction."""
+
+    def test_destroy_runs_ifconfig_destroy_on_the_host(
+        self,
+        logger: 'libioc.Logger.Logger',
+        mocker: typing.Any
+    ) -> None:
+        nic = libioc.NetworkInterface.NetworkInterface(
+            name="bridge0",
+            rename="bridge0",
+            auto_apply=False,
+            logger=logger
+        )
+        exec_mock = mocker.patch(
+            "libioc.helpers.exec",
+            return_value=("", "", 0)
+        )
+
+        nic.destroy_interface()
+
+        exec_mock.assert_called_once_with(
+            ["/sbin/ifconfig", "bridge0", "destroy"],
+            logger=logger
+        )

--- a/tests/test_Provisioning.py
+++ b/tests/test_Provisioning.py
@@ -25,10 +25,13 @@
 import typing
 import os.path
 import subprocess
+import unittest.mock
 import pytest
 
+import libioc.errors
 import libioc.Jail
 import libioc.Pkg
+import libioc.Provisioning
 
 class TestPuppetProvisioner(object):
     """Run Puppet Provisioner tests."""
@@ -63,3 +66,20 @@ class TestPuppetProvisioner(object):
         assert os.path.exists(
             os.path.join(existing_jail.root_path, "puppet.test")
         )
+
+
+class TestProvisionerMethod(object):
+    """Run tests for the provisioner method lookup."""
+
+    def test_unknown_method_raises_invalid_provisioner_method(
+        self,
+        logger: 'libioc.Logger.Logger'
+    ) -> None:
+        jail = unittest.mock.Mock()
+        jail.config = {"provision.method": "unknown-provisioner"}
+        jail.logger = logger
+
+        provisioner = libioc.Provisioning.Provisioner(jail=jail)
+
+        with pytest.raises(libioc.errors.InvalidProvisionerMethod):
+            provisioner.method

--- a/tests/test_Release.py
+++ b/tests/test_Release.py
@@ -24,6 +24,9 @@
 """Unit tests for the Release module."""
 import os.path
 
+import pytest
+
+import libioc.errors
 import libioc.Release
 
 class TestRelease(object):
@@ -42,3 +45,28 @@ class TestRelease(object):
             assert "daily_status_mail_rejects_enable=\"NO\"" in content
             assert "daily_status_include_submit_mailq=\"NO\"" in content
             assert "daily_submit_queuerun=\"NO\"" in content
+
+
+class TestAssetSignature(object):
+    """Run tests for release asset signature verification."""
+
+    def test_hash_mismatch_raises_invalid_release_asset_signature(
+        self,
+        logger: 'libioc.Logger.Logger'
+    ) -> None:
+
+        class ReleaseStub:
+
+            name = "13.5-RELEASE"
+            hashes = dict(base="expected-hash")
+
+            def __init__(self, logger: 'libioc.Logger.Logger') -> None:
+                self.logger = logger
+
+            def _read_asset_hash(self, asset_name: str) -> str:
+                return "mismatching-hash"
+
+        stub = ReleaseStub(logger)
+
+        with pytest.raises(libioc.errors.InvalidReleaseAssetSignature):
+            libioc.Release.ReleaseGenerator._check_asset_hash(stub, "base")

--- a/tests/test_Storage.py
+++ b/tests/test_Storage.py
@@ -28,8 +28,10 @@ import unittest.mock
 import pytest
 import json
 
+import libioc.events
 import libioc.Jail
 import libioc.Storage.Standalone
+import libioc.Storage.ZFSBasejail
 import libioc.ZFS
 
 
@@ -95,3 +97,17 @@ class TestStorageErrorPaths(object):
 
         with pytest.raises(NotImplementedError):
             storage.apply()
+
+    def test_zfs_basejail_apply_yields_the_config_event(
+        self,
+        logger: 'libioc.Logger.Logger'
+    ) -> None:
+        storage = libioc.Storage.ZFSBasejail.ZFSBasejailStorage(
+            jail=unittest.mock.Mock(),
+            zfs=unittest.mock.Mock(spec=libioc.ZFS.ZFS),
+            logger=logger
+        )
+
+        events = storage.apply(release=unittest.mock.Mock())
+
+        assert isinstance(next(events), libioc.events.BasejailStorageConfig)

--- a/tests/test_Storage.py
+++ b/tests/test_Storage.py
@@ -23,12 +23,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for Jail and Default Config."""
 import subprocess
+import unittest.mock
 
 import pytest
 import json
 
 import libioc.Jail
 import libioc.Storage.Standalone
+import libioc.ZFS
 
 
 class TestStorage(object):
@@ -76,3 +78,20 @@ class TestStorage(object):
             shell=True
         ).decode("utf-8")
         assert "/dev" not in stdout
+
+
+class TestStorageErrorPaths(object):
+    """Run tests for the storage backend error paths."""
+
+    def test_standalone_apply_is_not_implemented(
+        self,
+        logger: 'libioc.Logger.Logger'
+    ) -> None:
+        storage = libioc.Storage.Standalone.StandaloneJailStorage(
+            jail=unittest.mock.Mock(),
+            zfs=unittest.mock.Mock(spec=libioc.ZFS.ZFS),
+            logger=logger
+        )
+
+        with pytest.raises(NotImplementedError):
+            storage.apply()


### PR DESCRIPTION
- A failed download of the end-of-life release list logs the intended warning instead of raising a TypeError.
- The Provisioner raises the new InvalidProvisionerMethod error for an unknown provision.method value instead of crashing with an AttributeError.
- A failed release asset hash check raises InvalidReleaseAssetSignature instead of a TypeError, and the failure is now logged like the other update errors.
- Applying standalone storage reaches its intended NotImplementedError instead of a TypeError from an unsupported Logger argument.
- Applying ZFS basejail storage yields the BasejailStorageConfig event instead of crashing on a typo, and forwards the event scope like the NullFS backend.
- Destroying a network interface runs ifconfig destroy through libioc.helpers.exec instead of referencing the non-existent libioc.helper module.