### PR TITLE
Fix storage and fstab basejail bugs

### DIFF
--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -595,11 +595,18 @@ class JailFstab(Fstab):
                 List of destination strings that is skipped
         """
         BasejailStorage = libioc.Storage.Basejail.BasejailStorage
-        if isinstance(self.jail.storage_backend, BasejailStorage):
-            skip_destinations += list(map(
+        storage_backend = self.jail.storage_backend
+        if (storage_backend is not None) and issubclass(
+            storage_backend,
+            BasejailStorage
+        ):
+            # rebinding keeps the callers (default) list unchanged
+            skip_destinations = skip_destinations + list(map(
                 lambda x: str(x[1]),
-                # only _get_basejail_mounts exists, so this raises
-                self.jail.storage_backend.basejail_mounts
+                # cast for mypy: unbound backend methods take Storage as self
+                typing.cast(typing.Any, storage_backend)._get_basejail_mounts(
+                    self.jail.storage
+                )
             ))
         Fstab.parse_lines(
             self,

--- a/libioc/Config/Jail/File/Fstab.py
+++ b/libioc/Config/Jail/File/Fstab.py
@@ -759,8 +759,7 @@ class JailFstab(Fstab):
         release: typing.Optional['libioc.Release.ReleaseGenerator'] = None
     ) -> None:
         """Set a new release and save the updated file."""
-        # JailGenerator.release has no setter, so this raises AttributeError
-        self.jail.release = release  # type: ignore[misc, assignment]
+        self.release = release
         self.update_and_save()
 
     def __replace_magic_path(self, filepath: str) -> str:

--- a/libioc/Storage/__init__.py
+++ b/libioc/Storage/__init__.py
@@ -242,41 +242,48 @@ class Storage:
 
     def _mount_procfs(self) -> None:
         try:
-            if self.jail.config["mount_procfs"] is True:
-                libioc.helpers.exec([
-                    "mount"
-                    "-t",
-                    "procfs"
-                    "proc"
-                    f"{self.jail.root_dataset.mountpoint}/proc"
-                ])
+            if self.jail.config["mount_procfs"] is not True:
+                return
         except KeyError:
-            raise libioc.errors.MountFailed(
+            return
+
+        mountpoint = f"{self.jail.root_dataset.mountpoint}/proc"
+        try:
+            libioc.helpers.exec([
+                "mount",
+                "-t",
                 "procfs",
+                "proc",
+                mountpoint
+            ])
+        except libioc.errors.CommandFailure:
+            raise libioc.errors.MountFailed(
+                mountpoint=mountpoint,
                 logger=self.logger
             )
 
     # ToDo: Remove unused function?
     def _mount_linprocfs(self) -> None:
         try:
-            if not self.jail.config["mount_linprocfs"]:
+            if self.jail.config["mount_linprocfs"] is not True:
                 return
         except KeyError:
-            pass
+            return
 
         linproc_path = self._jail_mkdirp("/compat/linux/proc")
-
         try:
-            if self.jail.config["mount_procfs"] is True:
-                libioc.helpers.exec([
-                    "mount"
-                    "-t",
-                    "linprocfs",
-                    "linproc",
-                    linproc_path
-                ])
-        except KeyError:
-            raise libioc.errors.MountFailed("linprocfs")
+            libioc.helpers.exec([
+                "mount",
+                "-t",
+                "linprocfs",
+                "linproc",
+                linproc_path
+            ])
+        except libioc.errors.CommandFailure:
+            raise libioc.errors.MountFailed(
+                mountpoint=linproc_path,
+                logger=self.logger
+            )
 
     def _jail_mkdirp(
         self,

--- a/tests/test_Fstab.py
+++ b/tests/test_Fstab.py
@@ -30,6 +30,7 @@ import random
 import sys
 import os.path
 import subprocess
+import unittest.mock
 
 import libzfs
 
@@ -185,3 +186,56 @@ tmpfs /tmp tmpfs rw,mode=777 0 0 # {AUTO_COMMENT_IDENTIFIER}"""
 				]).wait()
 
 			assert os.path.exists(testfile) is False
+
+
+class TestJailFstab(object):
+	"""Run JailFstab unit tests."""
+
+	@pytest.fixture(autouse=True)
+	def mocked_host(self, mocker: typing.Any) -> None:
+		"""Replace the host so that parsing works without ZFS."""
+		mocker.patch(
+			"libioc.helpers_object.init_host",
+			return_value=mocker.MagicMock()
+		)
+
+	@pytest.fixture
+	def jail_stub(self, tmp_path: typing.Any) -> typing.Any:
+		"""Return a minimal jail double for JailFstab."""
+
+		class JailStub:
+
+			storage_backend: typing.Any = None
+			storage: typing.Any = None
+
+			def __init__(self, dataset_mountpoint: str) -> None:
+				self.dataset = unittest.mock.Mock()
+				self.dataset.mountpoint = dataset_mountpoint
+
+			@property
+			def release(self) -> typing.Any:
+				return None
+
+			def require_relative_path(self, path: str) -> None:
+				pass
+
+			def is_path_relative(self, path: str) -> bool:
+				return True
+
+		return JailStub(str(tmp_path))
+
+	def test_update_release_saves_the_file(
+		self,
+		jail_stub: typing.Any,
+		logger: 'libioc.Logger.Logger'
+	) -> None:
+		fstab = libioc.Config.Jail.File.Fstab.JailFstab(
+			jail=jail_stub,
+			logger=logger
+		)
+		release = unittest.mock.Mock()
+
+		fstab.update_release(release)
+
+		assert fstab.release is release
+		assert os.path.isfile(fstab.path) is True

--- a/tests/test_Fstab.py
+++ b/tests/test_Fstab.py
@@ -35,6 +35,7 @@ import unittest.mock
 import libzfs
 
 import libioc.Config.Jail.File.Fstab
+import libioc.Storage.NullFSBasejail
 
 class TestFstab(object):
 	"""Run Fstab unit tests."""
@@ -239,3 +240,41 @@ class TestJailFstab(object):
 
 		assert fstab.release is release
 		assert os.path.isfile(fstab.path) is True
+
+	def test_parse_lines_skips_basejail_destinations(
+		self,
+		jail_stub: typing.Any,
+		logger: 'libioc.Logger.Logger'
+	) -> None:
+		NullFSBasejailStorage = (
+			libioc.Storage.NullFSBasejail.NullFSBasejailStorage
+		)
+		root = f"{jail_stub.dataset.mountpoint}/root"
+		basejail = unittest.mock.Mock()
+		basejail.config = {"basejail_type": "nullfs"}
+		basejail.host.distribution.name = "FreeBSD"
+		basejail.release.root_dataset.mountpoint = (
+			"/iocage/releases/13.5-RELEASE/root"
+		)
+		basejail.release_snapshot.snapshot_name = "p0"
+		basejail.root_dataset.mountpoint = root
+		jail_stub.storage_backend = NullFSBasejailStorage
+		jail_stub.storage = unittest.mock.Mock()
+		jail_stub.storage.jail = basejail
+
+		fstab = libioc.Config.Jail.File.Fstab.JailFstab(
+			jail=jail_stub,
+			logger=logger
+		)
+		fstab.parse_lines(
+			f"/iocage/releases/13.5-RELEASE/root/bin {root}/bin nullfs ro 0 0\n"
+			f"/tmp/data {root}/data nullfs rw 0 0\n"
+		)
+
+		destinations = [
+			str(line["destination"])
+			for line in fstab
+			if isinstance(line, libioc.Config.Jail.File.Fstab.FstabLine)
+		]
+		assert f"{root}/data" in destinations
+		assert f"{root}/bin" not in destinations

--- a/tests/test_Jail.py
+++ b/tests/test_Jail.py
@@ -228,19 +228,12 @@ class TestNullFSBasejail(object):
         if "basejail_type" in data:
             assert data["basejail_type"] == "nullfs"
 
-    @pytest.mark.xfail(
-        reason=(
-            "enabling basejail after jail creation does not regenerate "
-            "the fstab basejail lines, so no nullfs mounts appear"
-        ),
-        strict=False
-    )
     def test_can_be_started(
         self,
         existing_jail: 'libioc.Jail.Jail',
         basedirs: typing.List[str]
     ) -> None:
-        """Test if a jail can be started."""
+        """Test if enabling basejail on an existing jail mounts the base."""
         existing_jail.config["mount_devfs"] = False
         existing_jail.config["basejail"] = True
         existing_jail.save()
@@ -249,15 +242,24 @@ class TestNullFSBasejail(object):
         existing_jail.start()
         assert existing_jail.running is True
 
+        # nullfs mounts from ZFS snapshot directories do not appear in
+        # getfsstat output on FreeBSD 13, so statfs proves each mount
         root_path = existing_jail.root_dataset.mountpoint
-        stdout = subprocess.check_output(
-            [f"/sbin/mount | grep {existing_jail.root_dataset.mountpoint}"],
-            shell=True
-        ).decode("utf-8")
-        assert "launch-scripts in stdout"
-        assert stdout.strip().count("\n") == len(basedirs)
         for basedir in basedirs:
-            assert f"{root_path}/{basedir}" in stdout
+            stdout = subprocess.check_output(
+                ["/bin/df", "-T", f"{root_path}/{basedir}"]
+            ).decode("utf-8")
+            assert "nullfs" in stdout
+
+        with pytest.raises(OSError):
+            with open(f"{root_path}/bin/.ioc-write-test", "w"):
+                pass
+
+        existing_jail.stop()
+        stdout = subprocess.check_output(
+            ["/bin/df", "-T", f"{root_path}/bin"]
+        ).decode("utf-8")
+        assert "nullfs" not in stdout
 
     def test_can_be_stopped(
         self,

--- a/tests/test_Storage.py
+++ b/tests/test_Storage.py
@@ -22,12 +22,14 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """Unit tests for Jail and Default Config."""
+import typing
 import subprocess
 import unittest.mock
 
 import pytest
 import json
 
+import libioc.errors
 import libioc.events
 import libioc.Jail
 import libioc.Storage.Standalone
@@ -111,3 +113,90 @@ class TestStorageErrorPaths(object):
         events = storage.apply(release=unittest.mock.Mock())
 
         assert isinstance(next(events), libioc.events.BasejailStorageConfig)
+
+
+class TestJailProcMounts(object):
+    """Run tests for the procfs and linprocfs mount helpers."""
+
+    @pytest.fixture
+    def proc_jail(self) -> 'unittest.mock.Mock':
+        jail = unittest.mock.Mock()
+        jail.config = {}
+        jail.root_dataset.mountpoint = "/iocage/jails/proc-test/root"
+        return jail
+
+    @pytest.fixture
+    def proc_storage(
+        self,
+        proc_jail: 'unittest.mock.Mock',
+        logger: 'libioc.Logger.Logger'
+    ) -> 'libioc.Storage.Storage':
+        return libioc.Storage.Storage(
+            jail=proc_jail,
+            zfs=unittest.mock.Mock(spec=libioc.ZFS.ZFS),
+            logger=logger
+        )
+
+    def test_mount_procfs_runs_a_valid_mount_command(
+        self,
+        proc_jail: 'unittest.mock.Mock',
+        proc_storage: 'libioc.Storage.Storage',
+        mocker: 'typing.Any'
+    ) -> None:
+        proc_jail.config["mount_procfs"] = True
+        exec_mock = mocker.patch(
+            "libioc.helpers.exec",
+            return_value=("", "", 0)
+        )
+
+        proc_storage._mount_procfs()
+
+        exec_mock.assert_called_once_with([
+            "mount",
+            "-t",
+            "procfs",
+            "proc",
+            "/iocage/jails/proc-test/root/proc"
+        ])
+
+    def test_mount_linprocfs_runs_a_valid_mount_command(
+        self,
+        proc_jail: 'unittest.mock.Mock',
+        proc_storage: 'libioc.Storage.Storage',
+        mocker: 'typing.Any'
+    ) -> None:
+        proc_jail.config["mount_linprocfs"] = True
+        linproc_path = "/iocage/jails/proc-test/root/compat/linux/proc"
+        mocker.patch(
+            "libioc.Storage.Storage._jail_mkdirp",
+            return_value=linproc_path
+        )
+        exec_mock = mocker.patch(
+            "libioc.helpers.exec",
+            return_value=("", "", 0)
+        )
+
+        proc_storage._mount_linprocfs()
+
+        exec_mock.assert_called_once_with([
+            "mount",
+            "-t",
+            "linprocfs",
+            "linproc",
+            linproc_path
+        ])
+
+    def test_failed_procfs_mount_raises_mount_failed(
+        self,
+        proc_jail: 'unittest.mock.Mock',
+        proc_storage: 'libioc.Storage.Storage',
+        mocker: 'typing.Any'
+    ) -> None:
+        proc_jail.config["mount_procfs"] = True
+        mocker.patch(
+            "libioc.helpers.exec",
+            side_effect=libioc.errors.CommandFailure(returncode=1)
+        )
+
+        with pytest.raises(libioc.errors.MountFailed):
+            proc_storage._mount_procfs()


### PR DESCRIPTION
- The procfs and linprocfs mount commands are built with proper arguments instead of concatenating to "mount-t" and "procfsproc", a missing config key skips the mount instead of raising, and MountFailed reports the mountpoint when the mount command fails.
- update_release sets the release attribute that Fstab declares instead of assigning to the jails read-only release property.
- Parsing a jail fstab skips the auto-created basejail destinations again: the storage backend class is checked with issubclass and queried through _get_basejail_mounts, and the mutable default argument is no longer mutated.